### PR TITLE
Duplicate records fix

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -150,10 +150,7 @@ function Get-SecretInfo
     $Filter = "*$Filter"
     $pattern = [WildcardPattern]::new($Filter)
     Invoke-lpass 'ls','-l' |
-        Where-Object { 
-            $_ -match $lsLongOutput | Out-Null
-            $pattern.IsMatch($Matches[2])
-        } |
+        Where-Object { $_ -match $lsLongOutput -and $pattern.IsMatch($Matches[2])} |
         ForEach-Object {
             $type = if ($Matches[3]) {
                 [SecretType]::PSCredential

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -141,6 +141,7 @@ function Remove-Secret
 
 function Get-SecretInfo
 {
+    [CmdletBinding()]
     param (
         [string] $Filter,
         [string] $VaultName,
@@ -150,7 +151,11 @@ function Get-SecretInfo
     $Filter = "*$Filter"
     $pattern = [WildcardPattern]::new($Filter)
     Invoke-lpass 'ls','-l' |
-        Where-Object { $_ -match $lsLongOutput -and $pattern.IsMatch($Matches[2])} |
+        Where-Object { 
+            $IsMatch = $_ -match $lsLongOutput -and $pattern.IsMatch($Matches[2])
+            if (-not $IsMatch ) { Write-Debug -Message "No match for: $_ `nThis record will be ignored." }
+            $IsMatch
+        } |
         ForEach-Object {
             $type = if ($Matches[3]) {
                 [SecretType]::PSCredential

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -152,9 +152,9 @@ function Get-SecretInfo
     $pattern = [WildcardPattern]::new($Filter)
     Invoke-lpass 'ls','-l' |
         Where-Object { 
-            $IsMatch = $_ -match $lsLongOutput -and $pattern.IsMatch($Matches[2])
+            $IsMatch = $_ -match $lsLongOutput 
             if (-not $IsMatch ) { Write-Debug -Message "No match for: $_ `nThis record will be ignored." }
-            $IsMatch
+            $IsMatch -and $pattern.IsMatch($Matches[2])
         } |
         ForEach-Object {
             $type = if ($Matches[3]) {


### PR DESCRIPTION
Here's an issue I had in my vault (2k+ records)
![image](https://user-images.githubusercontent.com/1980296/96080811-e75cf400-0e85-11eb-90ea-d64902a723b1.png)

After investigation, I found out `Get-Secret` implementation had a logic issue
```
  Where-Object { 
            $_ -match $lsLongOutput | Out-Null  # 1st  Sometimes is false
            $pattern.IsMatch($Matches[2])           # 2nd 
        } 
```

Whenever the first statement is false, the second one get evaluated against $Matches, which is not reset to $null and thus is equal to the last iteration of the loop. 

This means the second statement will pass and a record will be created with the value from the previous statement. 

Using : `Where-Object { $_ -match $lsLongOutput -and $pattern.IsMatch($Matches[2])} ` instead of the orignal statement fix the problem.
