### PR TITLE
Bracket replacement / isssue with Get-Secret in 0.5.x because of wildcard support.

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -30,10 +30,6 @@ function Invoke-lpass {
     throw "lpass executable not found or installed."
 }
 
-Function Select-MySecret([String]$Name, [Switch]$AsOutput) {
-    if ($AsOutput) { return $Name -replace '\[(id: \d*?)\]$', '<$1>' }
-    return $Name -replace '\<(id: \d*?)\>$', '[$1]' 
-}
 function Get-Secret
 {
     [CmdletBinding()]
@@ -45,10 +41,9 @@ function Get-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-    $Name = Select-MySecret -Name $Name
     # TODO error handling
 
-    if ($Name -match ".* \[id: (\d*)\]") {
+    if ($Name -match ".* \<id: (\d*)\>") {
         $Name = $Matches[1]
     }
 
@@ -81,7 +76,7 @@ function Set-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-    $Name = Select-MySecret -Name $Name
+
     if($Secret -is [string]) {
         $Secret = @{
             URL = "http://sn"
@@ -135,8 +130,8 @@ function Remove-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-    $Name = Select-MySecret -Name $Name
-    if ($Name -match ".* \[id: (\d*)\]") {
+
+    if ($Name -match ".* \<id: (\d*)\>") {
         $Name = $Matches[1]
     }
 
@@ -167,7 +162,7 @@ function Get-SecretInfo
             }
 
             [SecretInformation]::new(
-                    (Select-MySecret -Name $Matches[1] -AsOutput), 
+                    ($Matches[1] -replace '\[(id: \d*?)\]$', '<$1>'), 
                 $type,
                 $VaultName)
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -30,6 +30,10 @@ function Invoke-lpass {
     throw "lpass executable not found or installed."
 }
 
+Function Select-MySecret([String]$Name, [Switch]$AsOutput) {
+    if ($AsOutput) { return $Name -replace '\[(id: \d*?)\]$', '<$1>' }
+    return $Name -replace '\<(id: \d*?)\>$', '[$1]' 
+}
 function Get-Secret
 {
     [CmdletBinding()]
@@ -41,7 +45,7 @@ function Get-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-
+    $Name = Select-MySecret -Name $Name
     # TODO error handling
 
     if ($Name -match ".* \[id: (\d*)\]") {
@@ -77,6 +81,7 @@ function Set-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
+    $Name = Select-MySecret -Name $Name
     if($Secret -is [string]) {
         $Secret = @{
             URL = "http://sn"
@@ -130,7 +135,7 @@ function Remove-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-
+    $Name = Select-MySecret -Name $Name
     if ($Name -match ".* \[id: (\d*)\]") {
         $Name = $Matches[1]
     }
@@ -162,7 +167,7 @@ function Get-SecretInfo
             }
 
             [SecretInformation]::new(
-                $Matches[1],
+                    (Select-MySecret -Name $Matches[1] -AsOutput), 
                 $type,
                 $VaultName)
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -44,7 +44,7 @@ function Get-Secret
 
     # TODO error handling
 
-    if ($Name -match ".* \<id: (\d*)\>") {
+    if ($Name -match ".* \(id: (\d*)\)") {
         $Name = $Matches[1]
     }
 
@@ -131,7 +131,7 @@ function Remove-Secret
         [hashtable] $AdditionalParameters
     )
 
-    if ($Name -match ".* \<id: (\d*)\>") {
+    if ($Name -match ".* \(id: (\d*)\)") {
         $Name = $Matches[1]
     }
 
@@ -162,7 +162,7 @@ function Get-SecretInfo
             }
 
             [SecretInformation]::new(
-                ($Matches[1] -replace '\[(id: \d*?)\]$', '<$1>'), 
+                ($Matches[1] -replace '\[(id: \d*?)\]$', '($1)'), 
                 $type,
                 $VaultName)
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -41,6 +41,7 @@ function Get-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
+
     # TODO error handling
 
     if ($Name -match ".* \<id: (\d*)\>") {
@@ -76,7 +77,6 @@ function Set-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-
     if($Secret -is [string]) {
         $Secret = @{
             URL = "http://sn"
@@ -162,7 +162,7 @@ function Get-SecretInfo
             }
 
             [SecretInformation]::new(
-                    ($Matches[1] -replace '\[(id: \d*?)\]$', '<$1>'), 
+                ($Matches[1] -replace '\[(id: \d*?)\]$', '<$1>'), 
                 $type,
                 $VaultName)
         }


### PR DESCRIPTION
With the latest 0.5.x implementation, it seems the team added wildcard support for Get-Secret name parameter.
This is problematic for Lastpass extension since all the records name have a scheme like this one:

```
Shared-SomeFolder/SomeAccount [id: 774413942908781639]
```

![image](https://user-images.githubusercontent.com/1980296/96081632-bbdb0900-0e87-11eb-85d6-1b324e3a38f9.png)

Name parameter cannot contain wildcard characters.

To fix that, my suggestion is to replace the ID brackets by angle brackets and switch them back before processing a record.
The proposed fix do not deal with other brackets that the user could potentially have in its secret name though. 
