### PR TITLE
Dealing with Custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,26 @@ Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     lpassCommand = '& wsl lpass'
 }
 ```
+#### outputType
+##### Accepts: Default,Detailed,Raw
+```
+Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+    outputType = 'Detailed'
+```
+###### Default
+By default, standard credentials will return a PSCredentia, notes will be returned as a string and custom notes (Bank account, credit card, custom secret types) will be returned as a hashtable. 
+
+###### Detailed
+You can modify the default behavior so that notes and credentials also return as a hashtable. This has the advantage of exposing the URL and Notes field of credentials and also provide additional consistency for the Notes field should you want to compate multiple credentials Notes field (Simple notes Notes will also be in the Notes key)
+
+###### Raw
+This options return the items as is, with all fields and value in a multiline string
+This is the only mode that support duplicate fields name in custom type.
+```
+URL: https://www.google.ca
+Username: MyUser
+Password: MyPwd
+Notes: I am a note
+Notes is the only field that can be multiline and always the last field (if present).
+```
+

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -51,7 +51,6 @@ function Get-Secret
     }
 
     $res = Invoke-lpass 'show','--name', $Name, '--all'
-
     $Raw = ($res | Select-Object -Skip 1) -join "`n"
 
     if ($AdditionalParameters.outputType -eq 'Raw') {
@@ -75,8 +74,6 @@ function Get-Secret
         $Note = $raw.Substring($start)
     }
     $IsCustomType =  $AdditionalParameters.outputType -eq 'Detailed' -or $MyMatches.key.Contains('NoteType')
-
-
     If ($IsCustomType) {
         $Output = Get-ComplexSecret -Fields $MyMatches -Note $Note
     }
@@ -205,8 +202,6 @@ function Test-SecretVault
     return (Get-Command lpass -ErrorAction SilentlyContinue) -and ((lpass status) -match "Logged in as .*")
 }
 
-
-
 function Get-SimpleSecret {
     [CmdletBinding()]
     param (
@@ -239,7 +234,6 @@ function Get-ComplexSecret {
     
     if ($Dupes.count -gt 0) {
         $Dupesstr = ($dupes | ForEach-Object { $_.Group.key -join ',' }) -join "`n"
-
         
         Write-Error -Message @"
 The record contains multiple fields with the same name.
@@ -251,7 +245,6 @@ Secret will not be returned
         Write-Debug -Message 'Duplicates field name were detected. "" will be returned'
         return "" 
     }
-
 
     $Output = @{}
     if (![String]::IsNullOrEmpty($Note)) { 


### PR DESCRIPTION
Edit: I came up with a better implementation, highlighted in the last post regarding the whole Raw/Default/Detailed )

Currently, the module deal with "base types".
- Credentials
- Notes

But custom types are not dealt with properly. 
(For instance, my credit card record only returned the notes, which didn't serve me much) 
![image](https://user-images.githubusercontent.com/1980296/96562780-2a0c3b00-128f-11eb-92c7-4bf944a99d26.png)



As soon as you want to use it to retrieve your credit cards / banks accounts / Custom secrets with custom fields, it fails.
This pull request is to deal with the GET part of this problem. 
This pull request do not currently deal with SET / REMOVE and was opened to be discussed first before I go forward with additional work (I just want to make sure it make sense for you too / confirm desired implementation before doing the other cmdlet) 

Here is the premise of the changes (observed through Lastpass UI) 
- The Notes field is the only field that can be multiline
- The Notes field is always the last field (creating a custom type and adding Notes then something else will push the Notes fields down) 
- Custom types have a NoteType field returned with them, indicating they aren't ordinary
- Lastpass do not allow duplicate field name, but it does so in a case sensitive manner :( 
- Regardless of the previous statement, the NoteType field (which is a special hidden field) can be set with the same case (so you end up receiving a record with 2 fields called NoteType with the same case) 
- Lastpass field name do not accept the  column `:` character 


Because of the possible field name duplicate, I added an exception that will not return the secret if this occurs.
To palliate to this, I added an **outputType** parameter that can be set (optionally) to **Raw** or **Detailed**

Default continue to work as currently.
- Credentials return PScredentials, notes are returned as string and Custom type (bank account / other / user defined) are returned as hashtable.

Raw return  `wsl lpass show XXX  --all `  as a string (without the first line, which correspond to the secret name) 

Detailed return a hashtable for all records (So the notes of a simple notes will be in the hasthable Notes key) 

In all cases except raw, I chose to return an error if there was a field name defined more than once.
This should be an edge case really... 
I opted for the error and an empty secret but the alternative would be to return the secret as a raw string.
(Not sure which is better... The more I think of it, maybe returning the secret with a warning in its raw form would be better ? ) 
(Not getting your secret because of the duplicate field is frustrating, but setting a vault to Raw just for a few secrets is even more of a pain to deal with  I would think) 




I tested on a bunch of cases 

```
wsl lpass show XXX  --all # Custom note / 1 empty field
wsl lpass show XXX  --all # Credit card record
wsl lpass show XXX --all # Credential but empty
wsl lpass show XXX --all # credential
wsl lpass show XXX --all # Custom / Username 2 time with different cases
wsl lpass show XXX --all # Custom / similar ... 3 usernme fields :( with different cases
wsl lpass show XXX --all # Notes
wsl lpass show XXX --all # Notes but empty
wsl lpass show XXX --all # Creds with note
wsl lpass show XXX --all # Fake note with real note (Notes)
wsl lpass show XXX --all # Creds empty with Note
wsl lpass show XXX --all # NoteType custom parameter
```



