### PR TITLE
Bugfix/set secret invoke expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,23 @@ The module also have the following vault parameter, that can be provided at regi
 
 #### lpassCommand
 
-If your lpass CLI is installed at a custom location or that you need to launch it using an alternate mean, such as WSL, this can be accomplished by providing the `lpassCommand`
+This parameter allow the use of a custom command to be called before lpass (such as, but not limited to, wsl)
+
+##### Examples
+
+
+* Working with WSL
+
+```pwsh
+Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+    lpassCommand = 'wsl'
+}
+```
+
+
+#### lpassPath
+
+This parameter will allow to provide a custom lpass path location for the CLI
 
 ##### Examples
 
@@ -82,22 +98,6 @@ If your lpass CLI is installed at a custom location or that you need to launch i
 
 ```pwsh
 Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
-    lpassCommand = "/usr/bin/path/to/lpass"
-}
-```
-
-* Specifying a path with a space in it
-
-```pwsh
-Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
-    lpassCommand = "& '/usr/bin/Some Path With Spaces/lpass'"
-}
-```
-
-* Working with WSL
-
-```pwsh
-Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
-    lpassCommand = '& wsl lpass'
+    lpassPath = "/usr/bin/some path/to/lpass"
 }
 ```

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -24,7 +24,7 @@ function Invoke-lpass {
     $lpassPath = if ($null -ne $AdditionalParameters.lpassPath){"`"$($AdditionalParameters.lpassPath)`""} else {'lpass'}
    
     
-    if ($lpassCommand -ne '' -and ((& "$lpassCommand" "$lpassPath" --version ) -like 'LastPass CLI*') ) {
+    if ($lpassCommand -ne '' -and ((& "$lpassCommand" $lpassPath --version ) -like 'LastPass CLI*') ) {
         if ($InputObject) {
             $InputObject | & "$lpassCommand" $lpassPath @Arguments
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -24,7 +24,7 @@ function Invoke-lpass {
    
     if ((Invoke-Expression -Command "$lpassCommand --version" ) -like 'LastPass CLI*') {
         if ($InputObject) {
-            return $InputObject | Invoke-Expression -Command "$lpassCommand @Arguments"
+            return  Invoke-Expression -Command "$InputObject $lpassCommand @Arguments"
         }
         return Invoke-Expression -Command "$lpassCommand @Arguments"
     }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -20,13 +20,24 @@ function Invoke-lpass {
         $InputObject
     )
 
-    $lpassCommand = if ($null -ne $AdditionalParameters.lpassCommand){$AdditionalParameters.lpassCommand} else {'lpass'}
+    $lpassCommand = if ($null -ne $AdditionalParameters.lpassCommand){$AdditionalParameters.lpassCommand} else {''}
+    $lpassPath = if ($null -ne $AdditionalParameters.lpassPath){"`"$($AdditionalParameters.lpassPath)`""} else {'lpass'}
    
-    if ((Invoke-Expression -Command "$lpassCommand --version" ) -like 'LastPass CLI*') {
+    
+    if ($lpassCommand -ne '' -and ((& "$lpassCommand" "$lpassPath" --version ) -like 'LastPass CLI*') ) {
         if ($InputObject) {
-            return  Invoke-Expression -Command "$InputObject $lpassCommand @Arguments"
+            $InputObject | & "$lpassCommand" $lpassPath @Arguments
         }
-        return Invoke-Expression -Command "$lpassCommand @Arguments"
+        else {
+            return   & "$lpassCommand" $lpassPath @Arguments
+        }
+    } elseif (Get-Command $lpassPath) {
+        if ($InputObject) {
+            $InputObject | & $lpassPath @Arguments
+        }
+        else {
+            return   & $lpassCommand $lpassPath @Arguments
+        }
     }
     
     throw "lpass executable not found or installed."


### PR DESCRIPTION
#3  created an issue with the addition of InputObject.
Here's the suggested remediation.

I uses the old logic but separate lpassCommand and lpassPath into 2 distinct parameters so this can be dealt with accordingly without the use of invoke-expression. 

Disclaimer: I tested this on Windows only, not Linux but if you or the test confirm success, it should be good.