### PR TITLE
Feature/complex secrets and Set-Secret Edit / Add mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ Some limitations exist on this module, inherent to the CLI they are based on.
 
 **Custom credential types**
 - Custom notes can be read and edited but attempting to create a new item of a custom type will fail ([Open issue from 2016](https://github.com/lastpass/lastpass-cli/issues/190))
-- Custom notes  with duplicate field name will only return the first named field. Additionally, a **Raw** key will be added to the hashtable containing the original unprocessed note. 
+- Case-sensiive hashtables will be used if the fetched secret contain multiple time the same key name under different cases (eg: USERNAME,username)

--- a/README.md
+++ b/README.md
@@ -101,3 +101,16 @@ Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     lpassPath = "/usr/bin/some path/to/lpass"
 }
 ```
+#### outputType
+(Accept: Default,Detailed) 
+
+By default, regular credentials are returned as string (for notes) and PSCredential (for credentials) 
+Setting this parameter to **Detailed** will always return a hashtable. Effectively, this mean that the URL / Notes parameter of the regular credential will be exposed. 
+
+### Limitations
+
+Some limitations exist on this module, inherent to the CLI they are based on. 
+
+**Custom credential types**
+- Custom notes can be read and edited but attempting to create a new item of a custom type will fail ([Open issue from 2016](https://github.com/lastpass/lastpass-cli/issues/190))
+- Custom notes  with duplicate field name will only return the first named field. Additionally, a **Raw** key will be added to the hashtable containing the original unprocessed note. 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -132,8 +132,9 @@ function Set-Secret
         $Keys = $Secret.Keys.Where({$_ -notin $SpecialKeys })
 
         foreach ($k in $Keys) {
-            if ($k -is [securestring]){
-                $k = $k | ConvertFrom-SecureString
+            if ($Secret.$k -is [securestring]) {
+                $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.$k)
+                $Secret.$k = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
             }
             [Void]($sb.AppendLine("$($k): $($Secret.$k)"))
         }
@@ -141,7 +142,8 @@ function Set-Secret
         # Notes need to be on a new line
         if ($null -ne $Secret.Notes) {
             if ($Secret.Notes -is [securestring]) {
-                $Secret.Notes = $Secret.Notes | ConvertFrom-SecureString
+                $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.Notes)
+                $Secret.Notes = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
             }
             [Void]($sb.AppendLine("Notes: `n$($Secret.Notes)"))
         }
@@ -158,7 +160,10 @@ function Set-Secret
             Write-Verbose "Adding new secret" 
             $NoteTypeArgs = @()
             if ($null -ne $Secret.NoteType) {
-                if ($Secret.NoteType -is [securestring]) {$Secret.NoteType = $Secret.NoteType | ConvertFrom-SecureString}
+                if ($Secret.NoteType -is [securestring]) { 
+                    $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.NoteType)
+                    $Secret.NoteType = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+                }
                  $NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") 
             }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -201,7 +201,7 @@ function Set-Secret
                     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.NoteType)
                     $Secret.NoteType = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
                 }
-                $NoteTypeArgs = @("--note-type=$($Secret.NoteType)")
+                $NoteTypeArgs += "--note-type=$($Secret.NoteType)"
             }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs
             #Explicit sync so calling set again do not duplicate the secret (add --sync=now not fast enough)

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -34,6 +34,10 @@ $DefaultNoteTypeMap = @{
     #'visa' = ''        # Possibly deprecated
     'Wi-Fi Password'    = 'wifi'
 } 
+# These fields need special consideration when working with secrets.
+# Language / NoteType are fields that are part of any custom notes and always appear last (before Notes)
+#Notes field can appear in any secrets and is always the last field. It is also the only multiline field.
+$SpecialKeys = @('Language', 'NoteType', 'Notes')
 
 function Invoke-lpass {
     [CmdletBinding()]
@@ -161,8 +165,6 @@ function Set-Secret
 
     
     if ($Secret -is [hashtable]){
-        $SpecialKeys = @('Language', 'NoteType', 'Notes')
-
         if ($Secret.Keys.count -eq 1 -and $null -ne $Secret.Notes) {
             $Secret.URL = 'http://sn'
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -55,14 +55,14 @@ function Invoke-lpass {
         if ($InputObject) {
             return $InputObject | & "$lpassCommand" $lpassPath @Arguments 
         }
-            return   & "$lpassCommand" $lpassPath @Arguments 
+        return   & "$lpassCommand" $lpassPath @Arguments 
      } elseif (Get-Command $lpassPath) {
         if ($InputObject) {
             return  $InputObject | & $lpassPath @Arguments 
         }
-            return   & $lpassCommand $lpassPath @Arguments 
+        return   & $lpassCommand $lpassPath @Arguments 
     }
-    
+
     throw "lpass executable not found or installed."
 }
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -182,7 +182,7 @@ function Set-Secret
                 $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.Notes)
                 $Secret.Notes = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
             }
-            [Void]($sb.AppendLine("Notes: `n$($Secret.Notes)"))
+            $sb.AppendLine("Notes: `n$($Secret.Notes)") | Out-Null
         }
     } 
     

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -26,17 +26,17 @@ function Invoke-lpass {
     
     if ($lpassCommand -ne '' -and ((& "$lpassCommand" $lpassPath --version ) -like 'LastPass CLI*') ) {
         if ($InputObject) {
-            return $InputObject | & "$lpassCommand" $lpassPath @Arguments
+            return $InputObject | & "$lpassCommand" $lpassPath @Arguments 2>$null
         }
         else {
-            return   & "$lpassCommand" $lpassPath @Arguments
+            return   & "$lpassCommand" $lpassPath @Arguments 2>$null
         }
     } elseif (Get-Command $lpassPath) {
         if ($InputObject) {
-            return  $InputObject | & $lpassPath @Arguments
+            return  $InputObject | & $lpassPath @Arguments 2>$null
         }
         else {
-            return   & $lpassCommand $lpassPath @Arguments
+            return   & $lpassCommand $lpassPath @Arguments 2>$null
         }
     }
     
@@ -82,8 +82,7 @@ function Get-Secret
         })
 
         if ([String]::IsNullOrEmpty($Raw)) {
-            Write-Error 'Unable to retrieve secret. Make sure you are logged in and try again.'
-            return ""
+            return $null # Error will be returned.
         }
 
     # Notes is always the last item. This is also the only field that can be multiline.
@@ -150,8 +149,8 @@ function Set-Secret
     } 
     
     try {
-        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
-          $SecretExists = $null -ne $res 
+        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction Stop 
+        $SecretExists = $null -ne $res 
 
         if ($SecretExists) {
             Write-Verbose "Editing secret" 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -292,19 +292,21 @@ function Get-SimpleSecret {
         $Note
     )
     
-    $IsCredentials = $Fields.where( { $_.key -in @('Username', 'Password') }, 'first').count -eq 1
-    if ($IsCredentials) {
-        $username = $Fields.Where( { $_.key -eq 'Username' }, 'first') | Select-Object -ExpandProperty value
+    $username = $Fields.Where( { $_.key -eq 'Username' }, 'first') | Select-Object -ExpandProperty value
+    $password = $Fields.Where( { $_.key -eq 'Password' }, 'first') | Select-Object -ExpandProperty value
+    # Credentials 
+    if ($username -or $password) {
         if ($null -eq $username) { $username = '' }
-        $password = $Fields.Where( { $_.key -eq 'Password' }, 'first') | Select-Object -ExpandProperty value
         if ($null -eq $password) { $password = '' }
         if ("" -ne $password) { $password = $password | ConvertTo-SecureString -AsPlainText -Force }
-        $output = [System.Management.Automation.PSCredential]::new($username, $password)
+        return [System.Management.Automation.PSCredential]::new($username, $password)
     }
-    else {
-        if ($null -eq $Note) { $output = "" } else { $output = $Note }
+    # Secure Note
+    if ($null -ne $Note) {
+        return $Note
     }
-    return $output
+    # Empty secret
+    return ''
 }
 
 function Get-ComplexSecret {
@@ -315,7 +317,7 @@ function Get-ComplexSecret {
     )
     $Dupes = ($Fields | Group-Object key).Where( { $_.Count -gt 1 })
     
-    if ($Dupes.count -gt 0) {
+    if ($Dupes.Count -gt 0) {
         Write-Verbose 'Creating case-sensitve hashtable'
         $Output = [hashtable]::new([System.StringComparer]::InvariantCulture)
     } else {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -280,25 +280,16 @@ function Get-ComplexSecret {
     $Dupes = ($Fields | Group-Object key).Where( { $_.Count -gt 1 })
     
     if ($Dupes.count -gt 0) {
-        $Dupesstr = ($dupes | ForEach-Object { $_.Group.key -join ',' }) -join "`n"
-        
-        Write-Warning -Message @"
-The record contains multiple fields with the same name.
-$Dupesstr
-A Raw parameter will be added to the returned object with the raw object. Only the first field found with a duplicated name will be included in the parsed object.
-
-"@
-
+        Write-Verbose 'Creating case-sensitve hashtable'
+        $Output = [hashtable]::new([System.StringComparer]::InvariantCulture)
+    } else {
+        $Output = @{}
     }
-
-    $Output = @{}
+    
     if (![String]::IsNullOrEmpty($Note)) { 
         $Output.Notes = $Note
         $Fields = $Fields | Select-Object -SkipLast 1
     }
-
-    # If there's duplicate, Raw become a reserved key that will contains the raw output
-    if ($Dupes.count -gt 0) {$Output.Add('Raw',$Raw)}
 
     Foreach ($f in $Fields) {
         try {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -122,7 +122,9 @@ function Get-Secret
             }
         })
 
-    # Notes is always the last item. This is also the only field that can be multiline.
+    # Notes is always the last item (lpass wise). This is also the only field that can be multiline.
+    # Any matching items after the first "Notes" key need to be discarded as it is not an item,
+    # but rather just part of the notes.
     $HasNote = $MyMatches.key -ccontains 'Notes' 
     if ($HasNote) {
         $start = $MyMatches.Where({$_.Key -ceq 'Notes'},'First')[0].valueIndex

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -132,11 +132,17 @@ function Set-Secret
         $Keys = $Secret.Keys.Where({$_ -notin $SpecialKeys })
 
         foreach ($k in $Keys) {
+            if ($k -is [securestring]){
+                $k = $k | ConvertFrom-SecureString
+            }
             [Void]($sb.AppendLine("$($k): $($Secret.$k)"))
         }
 
         # Notes need to be on a new line
         if ($null -ne $Secret.Notes) {
+            if ($Secret.Notes -is [securestring]) {
+                $Secret.Notes = $Secret.Notes | ConvertFrom-SecureString
+            }
             [Void]($sb.AppendLine("Notes: `n$($Secret.Notes)"))
         }
     } 
@@ -151,7 +157,10 @@ function Set-Secret
         } else {
             Write-Verbose "Adding new secret" 
             $NoteTypeArgs = @()
-            if ($null -ne $Secret.NoteType) { $NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") }
+            if ($null -ne $Secret.NoteType) {
+                if ($Secret.NoteType -is [securestring]) {$Secret.NoteType = $Secret.NoteType | ConvertFrom-SecureString}
+                 $NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") 
+            }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs
         }
        

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -156,7 +156,7 @@ function Set-Secret
     
     
     if ($Secret -is [string]) {
-        $Secret = @{Notes = $Secret}
+        $Secret = @{URL = ' http://sn';Notes = $Secret}
     } elseif ($Secret -is [pscredential]) {
         $Secret = @{Username = $Secret.Username; Password = $Secret.GetNetworkCredential().password}
     }
@@ -165,8 +165,12 @@ function Set-Secret
     
     if ($Secret -is [hashtable]){
         $SpecialKeys = @('Language', 'NoteType', 'Notes')
-        $Keys = $Secret.Keys.Where({$_ -notin $SpecialKeys })
 
+        if ($Secret.Keys.count -eq 1 -and $null -ne $Secret.Notes) {
+            $Secret.URL = 'http://sn'
+        }
+
+        $Keys = $Secret.Keys.Where({$_ -notin $SpecialKeys })
         foreach ($k in $Keys) {
             if ($Secret.$k -is [securestring]) {
                 $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.$k)

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -190,7 +190,7 @@ function Set-Secret
     } 
     
     try {
-        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name, '2>null' -ErrorAction Stop 
+        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name, '2>/dev/null' -ErrorAction Stop 
         $SecretExists = $null -ne $res 
 
         if ($SecretExists) {
@@ -207,6 +207,8 @@ function Set-Secret
                 $NoteTypeArgs = @("--note-type=$($Secret.NoteType)")
             }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs
+            #Explicit sync so calling set again do not duplicate the secret (add --sync=now not fast enough)
+            Invoke-lpass 'sync' 
         }
        
     }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -8,6 +8,33 @@ using namespace Microsoft.PowerShell.SecretManagement
 # 3. The username of the secret
 $lsLongOutput = "\d\d\d\d-\d\d-\d\d \d\d:\d\d ((.*) \[id: \d*\]) \[username: (.*)\]"
 
+    # Custom notes in lpass CLI are a bit of a mess.
+    # For default types
+    # Get operation will return the value
+    # Set operation will only accept the key
+    # This is to convert value obtained from Get when doing a Set. 
+$DefaultNoteTypeMap = @{
+    'Address'           = 'address'
+    # 'amex' = ''       # Possibly deprecated            
+    'Bank Account'      = 'bank'
+    'Credit Card'       = 'credit-card'
+    'Database'          = 'database'
+    "Driver's License"  = 'drivers-license'
+    'Email Account'     = 'email'
+    'Health Insurance'  = 'health-insurance'
+    'Instant Messenger' = 'im'
+    'Insurance'         = 'insurance'
+    #'mastercard' = ''  # Possibly deprecated
+    'Membership'        = 'membership'
+    'Passport'          = 'passport'
+    'Server'            = 'server'
+    'Software License'  = 'software-license'
+    'SSH Key'           = 'ssh-key'
+    'Social Security'   = 'ssn'
+    #'visa' = ''        # Possibly deprecated
+    'Wi-Fi Password'    = 'wifi'
+} 
+
 function Invoke-lpass {
     [CmdletBinding()]
     param (
@@ -163,7 +190,7 @@ function Set-Secret
                     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.NoteType)
                     $Secret.NoteType = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
                 }
-                 $NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") 
+                $NoteTypeArgs = @("--note-type=$($Secret.NoteType)")
             }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs
         }
@@ -298,6 +325,8 @@ function Get-ComplexSecret {
             Write-Warning "$($f.key) field was not added."
         }
     }
-   
+    if ($DefaultNoteTypeMap.ContainsKey($Output.NoteType)) {
+        $Output.NoteType = $DefaultNoteTypeMap.Item($Output.NoteType)
+    }
     return $Output
 }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -149,7 +149,7 @@ function Set-Secret
     } 
     
     try {
-        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction Stop 
+        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name, '2>&1' -ErrorAction Stop 
         $SecretExists = $null -ne $res 
 
         if ($SecretExists) {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -26,17 +26,17 @@ function Invoke-lpass {
     
     if ($lpassCommand -ne '' -and ((& "$lpassCommand" $lpassPath --version ) -like 'LastPass CLI*') ) {
         if ($InputObject) {
-            return $InputObject | & "$lpassCommand" $lpassPath @Arguments 2>$null
+            return $InputObject | & "$lpassCommand" $lpassPath @Arguments 
         }
         else {
-            return   & "$lpassCommand" $lpassPath @Arguments 2>$null
+            return   & "$lpassCommand" $lpassPath @Arguments 
         }
     } elseif (Get-Command $lpassPath) {
         if ($InputObject) {
-            return  $InputObject | & $lpassPath @Arguments 2>$null
+            return  $InputObject | & $lpassPath @Arguments 
         }
         else {
-            return   & $lpassCommand $lpassPath @Arguments 2>$null
+            return   & $lpassCommand $lpassPath @Arguments 
         }
     }
     

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -149,7 +149,7 @@ function Set-Secret
     } 
     
     try {
-        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name, '2>&1' -ErrorAction Stop 
+        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name, "2>$null" -ErrorAction Stop 
         $SecretExists = $null -ne $res 
 
         if ($SecretExists) {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -173,7 +173,7 @@ function Set-Secret
                 $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.$k)
                 $Secret.$k = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
             }
-            [Void]($sb.AppendLine("$($k): $($Secret.$k)"))
+            $sb.AppendLine("$($k): $($Secret.$k)") | Out-Null
         }
 
         # Notes need to be on a new line

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -124,7 +124,7 @@ function Get-Secret
     # Notes is always the last item. This is also the only field that can be multiline.
     $HasNote = $MyMatches.key -ccontains 'Notes' 
     if ($HasNote) {
-        $start = $MyMatches.Where({$_.Key -ceq 'Notes'},'Last')[0].valueIndex
+        $start = $MyMatches.Where({$_.Key -ceq 'Notes'},'First')[0].valueIndex
         $Note = $raw.Substring($start)
         $MyMatches = $MyMatches.Where({$_.ValueIndex -lt $start})
     }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -144,12 +144,12 @@ function Set-Secret
     try {
         $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
           $SecretExists = $null -ne $res 
-        Write-Verbose $SecretExists.ToString() -Verbose
+
         if ($SecretExists) {
-            Write-Verbose "Editing secret" -Verbose
+            Write-Verbose "Editing secret" 
             $sb.ToString() | Invoke-lpass 'edit', '--non-interactive', $Name
         } else {
-            Write-Verbose "Adding new secret" -Verbose
+            Write-Verbose "Adding new secret" 
             $NoteTypeArgs = @()
             if ($null -ne $Secret.NoteType) { $NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") }
             $sb.ToString() | Invoke-lpass 'add', $Name, '--non-interactive', $NoteTypeArgs
@@ -162,35 +162,6 @@ function Set-Secret
     }
     return $true
 
-    
-      
-    # if($Secret.UserName) {
-    #     $sb.Append("Username: ").AppendLine($Secret.UserName)
-    #     $sb.Append("login: ").AppendLine($Secret.UserName)
-    # }
-
-    # if($Secret.Password) {
-    #     $pass = $Secret.Password
-    #     if ($Secret -is [pscredential]) {
-    #         $pass = $Secret.GetNetworkCredential().password
-    #     } elseif ($pass -is [securestring]) {
-    #         $pass = $pass | ConvertFrom-SecureString
-    #     }
-
-    #     $sb.Append("Password: ").AppendLine($pass)
-    #     $sb.Append("password: ").AppendLine($pass)
-    #     $sb.Append("sudo_password: ").AppendLine($pass)
-    # }
-
-    # if($Secret.URL) {
-    #     $sb.Append("URL: ").AppendLine($Secret.URL)
-    # }
-
-    # if($Secret.Notes) {
-    #     $sb.AppendLine("Notes:").AppendLine($Secret.Notes)
-    # }
-
-   
 }
 
 function Remove-Secret


### PR DESCRIPTION
This is #6 with less questions and more code. 
This do include #7 changes too since I couldn't do anything without them (Set-Secret was not working, after all) 

For the context of this PR, 
Complex type = any credential type included with lastpass that is not a note or user/password type. 
(eg: Bank account, credit card, etc...)

Custom type = any custom type defined by the org. and / or user 


This PR goal is to address the following: 
- Get-Secret with complex types (Bank account, credit card) and Custom user defined type currently return only the Notes fields
- Set-Secret to either add or edit existing secret (In main, it always add with no regards for existing secret) 
- Add a **outputType** parameter, that can be set to **Detailed** so normal credentials return as a hashtable containing all the fields instead of a PsCredential (so we get the Notes / Url) fields 
(Maybe this behavior should be the default and instead a outputType with Simple added to return "pscredential" for simple credential and / or maybe there shouldn't be any parameter and everything should be a hashtable ?) 
- In Set-Secret, changed initial use of ConvertFrom-SecureString (which... did not have the -AsPlainText parameter) for the Interop statement, which work with 5.1 (and still work with no issue with 7.1)


Some rough edges. 

- Could not find specified account(s)  error message when using Set-Secret to Add a secret. 
![image](https://user-images.githubusercontent.com/1980296/97106214-9d022100-1696-11eb-8b15-37387df2f1dc.png)
Really not sure why it happens. I never saw an ErrorAction SilentlyContinue being disrespected like that. Maybe it is tied to the `&`. 

- Currently, multiline notes that would have a string that start with something that looks like a key / value pair used by lastpass will vause issue when comes the time to add / edit the secret. 
Take for instance this note 
```
I am a silly note
For helpdesk support, contact 1-333-333-3333
Pin: 9000
```
That last line when sent via input is problematic because it is exactly how key & values are defined. 
There's a Notes parameter but I wasn't successful to pass a multiline string there. 
(It might just be that I tried to escape wrong or that multiline notes using --notes along with (or without) input object are not supported. 

- Complex note types
```
$NoteTypeArgs = @("--note-type=$($Secret.NoteType.ToLower().replace(' ','-'))") 
```
Currently, I used that statement.
Tested with Credit Card but I need to test with other complex types
This is because the `lpass show` return "Credit Card" as note type but it want a specific set of valid type when using the --note-type parameter which seems to lower case / dash as space types (eg: credit-card).

That being said, there's a dozen of type so maybe a map will be required if the translation do not work out of the box for the defined types. 

(Also, any custom types is not supported when adding secret (that's a lpass CLI limitation)

