### PR TITLE
Update Test-SecretVault and Remove-Secret to work with lpassCommand

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -137,7 +137,7 @@ function Remove-Secret
         $Name = $Matches[1]
     }
 
-    lpass rm $Name
+    Invoke-lpass 'rm', $Name
     return $?
 }
 
@@ -181,5 +181,6 @@ function Test-SecretVault
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-    return (Get-Command lpass -ErrorAction SilentlyContinue) -and ((lpass status) -match "Logged in as .*")
+    $status = Invoke-lpass 'status' -ErrorAction SilentlyContinue
+    return ($status -match "Logged in as .*")
 }


### PR DESCRIPTION
A quick update to `Remove-Secret` and `Test-SecretVault` so they work correctly with `Invoke-lpass`. Tested on Win10/WSL.