### PR TITLE
Misc fixes and a couple tests

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -70,7 +70,7 @@ function Invoke-lpass {
     $UseNative = $lpassCommand -eq ''
     $UseCommand = -not $UseNative
 
-    if (($UseNative -and  (Get-Command $lpassPath -EA 0)) -or 
+    if (($UseNative -and -not (Get-Command $lpassPath -EA 0)) -or 
         ($UseCommand -and (& "$lpassCommand" $lpassPath --version ) -notlike 'LastPass CLI*')) {
         throw "lpass executable not found or installed."
     }
@@ -78,18 +78,17 @@ function Invoke-lpass {
     # All other implementations seemed to succeed on 1 or more platform but failed when considering Windows (Wsl) / Linux / Mac together
     if ($InputObject) {
         switch ($true) {
-            {$UseNative -and $IgnoreErrors}  {$result = $InputObject | & $lpassPath @Arguments; break}
-            {$UseNative}                     {$result = $InputObject | & $lpassPath @Arguments 2>&1; break}
-            {$UseCommand -and $IgnoreErrors} {$result = $InputObject | & "$lpassCommand" $lpassPath @Arguments; break}
-            {$UseCommand}                    {$result = $InputObject | & "$lpassCommand" $lpassPath @Arguments 2>&1; break}
+            {$UseNative -and $IgnoreErrors}  {$result = $InputObject | & $lpassPath @Arguments 2>&1; break}
+            {$UseNative}                     {$result = $InputObject | & $lpassPath @Arguments; break}
+            {$UseCommand -and $IgnoreErrors} {$result = $InputObject | & "$lpassCommand" $lpassPath @Arguments 2>&1; break}
+            {$UseCommand}                    {$result = $InputObject | & "$lpassCommand" $lpassPath @Arguments; break}
         }
     } else {
         switch ($true) {
-            { $UseNative -and $IgnoreErrors }   {$result = & $lpassPath @Arguments; break}
-            { $UseNative }                      {$result = & $lpassPath @Arguments 2>&1; break}
-            { $UseCommand -and $IgnoreErrors }  {$result = & "$lpassCommand" $lpassPath @Arguments; break}
-            { $UseCommand }                     {$result = & "$lpassCommand" $lpassPath @Arguments 2>&1; break}
-        
+            { $UseNative -and $IgnoreErrors }   {$result = & $lpassPath @Arguments 2>&1; break}
+            { $UseNative }                      {$result = & $lpassPath @Arguments; break}
+            { $UseCommand -and $IgnoreErrors }  {$result = & "$lpassCommand" $lpassPath @Arguments 2>&1; break}
+            { $UseCommand }                     {$result = & "$lpassCommand" $lpassPath @Arguments; break}
         }
     }
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -201,7 +201,7 @@ function Set-Secret
     try {
         $res = Invoke-lpass 'show', '--sync=now', '--name', $Name
         # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
-        $SecretExists = $res.ToString() -ne "Error: Could not find specified account(s)."
+        $SecretExists = $null -ne $res -and $res.ToString() -ne "Error: Could not find specified account(s)."
 
         if ($SecretExists) {
             Write-Verbose "Editing secret" 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -350,10 +350,11 @@ function Get-ComplexSecret {
         $Fields,
         $Note
     )
-    # Notes is removed from the fields. If present, this mean we have another field using that name under a different case.
-    $Dupes = ($Fields | Group-Object key).Where( { $_.Count -gt 1 }) -or ($Fields.Contains('Notes') -and ![String]::IsNullOrEmpty($Note))
     
-    if ($Dupes.Count -gt 0) {
+    $Dupes = ($Fields | Group-Object key).Where( { $_.Count -gt 1 })
+    # Notes is removed from the fields. If present, this mean we have another field using that name under a different case.
+    $DupeNote = ($Fields.Contains('Notes') -and ![String]::IsNullOrEmpty($Note))
+    if ($Dupes.Count -gt 0 -or $DupeNote) {
         Write-Verbose 'Creating case-sensitve hashtable'
         $Output = [hashtable]::new([System.StringComparer]::InvariantCulture)
     } else {
@@ -361,11 +362,7 @@ function Get-ComplexSecret {
     }
     
     if (![String]::IsNullOrEmpty($Note)) { 
-        #The Notes field is ALWAYS the last field.
-        #It is also the only field that can be multiline.
-        #This is why we set the Notes to $Notes and ignore the last field when a Notes field exist.
         $Output.Notes = $Note
-        $Fields = $Fields | Select-Object -SkipLast 1
     }
 
     Foreach ($f in $Fields) {

--- a/build.ps1
+++ b/build.ps1
@@ -2,6 +2,10 @@
 param (
     [Parameter()]
     [switch]
+    $Test,
+
+    [Parameter()]
+    [switch]
     $Package,
 
     [Parameter()]
@@ -10,6 +14,10 @@ param (
 )
 
 Push-Location $PSScriptRoot
+
+if ($Test) {
+    Invoke-Pester test
+}
 
 if ($Package) {
     $outDir = Join-Path 'out' 'SecretManagement.LastPass'

--- a/test/Extension.Tests.ps1
+++ b/test/Extension.Tests.ps1
@@ -1,0 +1,122 @@
+Describe 'SecretManagement.LastPass tests' {
+    BeforeAll {
+        & $PSScriptRoot/reload.ps1
+        $VaultName = 'LastPass.Tests'
+    }
+
+    BeforeEach {
+        $secretName = "tests/$((New-Guid).Guid)"
+    }
+
+    It 'LastPass vault is registered' {
+        Get-SecretVault $VaultName | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Can store a string secret which is treated like a securestring' {
+        $secretText = 'This is my string secret'
+        Set-Secret -Name $secretName -Vault $VaultName -Secret $secretText
+
+        $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
+        $secretInfo.Name | Should -BeLike "$secretName (id:*)"
+        $secretInfo.Type | Should -BeExactly 'Unknown'
+        $secretInfo.VaultName | Should -BeExactly $VaultName
+        $secret = Get-Secret -Name $secretName -AsPlainText -Vault $VaultName
+        $secret | Should -BeExactly $secretText
+
+        Remove-Secret -Name $secretName -Vault $VaultName
+        { 
+            Get-Secret -Name $secretName -Vault $VaultName -ErrorAction Stop
+        } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
+    }
+
+    It 'Can store a secure string secret' {
+        $secretText = 'This is my securestring secret'
+        Set-Secret -Name $secretName -Vault $VaultName -Secret ($secretText | ConvertTo-SecureString -AsPlainText)
+
+        $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
+        $secretInfo.Name | Should -BeLike "$secretName (id:*)"
+        $secretInfo.Type | Should -BeExactly 'Unknown'
+        $secretInfo.VaultName | Should -BeExactly $VaultName
+
+        $secret = Get-Secret -Name $secretName -AsPlainText -Vault $VaultName
+        $secret | Should -BeExactly $secretText
+
+        Remove-Secret -Name $secretName -Vault $VaultName
+        { Get-Secret -Name $secretName -Vault $VaultName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
+    }
+
+    # Skipping because I don't think this extension supports byte array.
+    It 'Can store a byte array secret' -Skip {
+        $secretText = 'This is my byte array secret'
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($secretText)
+        Set-Secret -Name $secretName -Vault $VaultName -Secret $bytes
+
+        $secretInfo = Get-SecretInfo -Name $secretName
+        $secretInfo.Name | Should -BeExactly $secretName
+        $secretInfo.Type | Should -BeExactly 'ByteArray'
+        $secretInfo.VaultName | Should -BeExactly $VaultName
+
+        $secret = Get-Secret -Name $secretName
+        [System.Text.Encoding]::UTF8.GetString($secret) | Should -BeExactly $secretText
+
+        Remove-Secret -Name $secretName -Vault $VaultName
+        { Get-Secret -Name $secretName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
+    }
+
+    It 'Can store a PSCredential secret' {
+        $secretText = 'This is my pscredential secret'
+        $secret = [PSCredential]::new('myUser', ($secretText | ConvertTo-SecureString -AsPlainText))
+        Set-Secret -Name $secretName -Vault $VaultName -Secret $secret
+
+        $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
+        $secretInfo.Name | Should -BeLike "$secretName (id:*)"
+        $secretInfo.Type | Should -BeExactly 'PSCredential'
+        $secretInfo.VaultName | Should -BeExactly $VaultName
+
+        $secret = Get-Secret -Name $secretName -Vault $VaultName
+        $secret.UserName | Should -BeExactly 'myUser'
+        $secret.Password | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $secretText
+
+        Remove-Secret -Name $secretName -Vault $VaultName
+        { Get-Secret -Name $secretName -Vault $VaultName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
+    }
+
+    # Skipping because I don't think this extension supports arbitrary hashtables.
+    It 'Can store hashtable secret' -Skip {
+        $secretText = 'This is my hashtable secret'
+        $cred = [pscredential]::new('myUser', ($secretText | convertto-securestring -asplaintext))
+        $securestring = $secretText | convertto-securestring -asplaintext
+        $hashtable = @{
+            a = 1
+            b = $cred
+            c = @{
+                d = 'nested'
+                e = $cred
+                f = $securestring
+            }
+            g = $securestring
+        }
+
+        Set-Secret -Name $secretName -Vault $VaultName -Secret $hashtable
+        $secretInfo = Get-SecretInfo -Name $secretName
+        $secretInfo.Name | Should -BeExactly $secretName
+        $secretInfo.Type | Should -BeExactly 'Hashtable'
+        $secretInfo.VaultName | Should -BeExactly $VaultName
+
+        $secret = Get-Secret -Name $secretName -AsPlainText
+        $secret.a | Should -Be 1
+        $secret.b | Should -BeOfType [PSCredential]
+        $secret.b.UserName | Should -BeExactly 'myUser'
+        $secret.b.Password | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $secretText
+        $secret.c | Should -BeOfType [Hashtable]
+        $secret.c.d | Should -BeExactly 'nested'
+        $secret.c.e | Should -BeOfType [PSCredential]
+        $secret.c.e.UserName | Should -BeExactly 'myUser'
+        $secret.c.e.Password | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $secretText
+        $secret.c.f | Should -BeExactly $secretText
+        $secret.g | Should -BeExactly $secretText
+
+        Remove-Secret -Name $secretName -Vault $VaultName
+        { Get-Secret -Name $secretName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
+    }
+}

--- a/test/Extension.Tests.ps1
+++ b/test/Extension.Tests.ps1
@@ -1,6 +1,3 @@
-# Change this to however you invoke lpass
-$IsNotLoggedIn = (lpass status 2>&1) -notmatch "Logged in as .*"
-
 Describe 'SecretManagement.LastPass tests' {
     BeforeAll {
         & $PSScriptRoot/reload.ps1
@@ -15,7 +12,7 @@ Describe 'SecretManagement.LastPass tests' {
         Get-SecretVault $VaultName | Should -Not -BeNullOrEmpty
     }
 
-    It 'Can store a string secret which is treated like a securestring' -Skip:$IsNotLoggedIn {
+    It 'Can store a string secret which is treated like a securestring' {
         $secretText = 'This is my string secret'
         Set-Secret -Name $secretName -Vault $VaultName -Secret $secretText
 
@@ -32,7 +29,7 @@ Describe 'SecretManagement.LastPass tests' {
         } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
     }
 
-    It 'Can store a secure string secret' -Skip:$IsNotLoggedIn {
+    It 'Can store a secure string secret' {
         $secretText = 'This is my securestring secret'
         Set-Secret -Name $secretName -Vault $VaultName -Secret ($secretText | ConvertTo-SecureString -AsPlainText)
 
@@ -48,7 +45,7 @@ Describe 'SecretManagement.LastPass tests' {
         { Get-Secret -Name $secretName -Vault $VaultName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
     }
 
-    It 'Can store a PSCredential secret' -Skip:$IsNotLoggedIn {
+    It 'Can store a PSCredential secret' {
         $secretText = 'This is my pscredential secret'
         $secret = [PSCredential]::new('myUser', ($secretText | ConvertTo-SecureString -AsPlainText))
         Set-Secret -Name $secretName -Vault $VaultName -Secret $secret
@@ -64,11 +61,6 @@ Describe 'SecretManagement.LastPass tests' {
 
         Remove-Secret -Name $secretName -Vault $VaultName
         { Get-Secret -Name $secretName -Vault $VaultName -ErrorAction Stop } | Should -Throw -ErrorId 'GetSecretNotFound,Microsoft.PowerShell.SecretManagement.GetSecretCommand'
-    }
-
-    It 'Logged out works' -Skip:(!$IsNotLoggedIn) {
-        { Get-Secret -Name "asdf" -Vault $VaultName -ErrorAction Stop } |
-            Should -Throw -ExceptionType Microsoft.PowerShell.SecretManagement.PasswordRequiredException
     }
 
     #region Tests to add back in later from Steve's module

--- a/test/reload.ps1
+++ b/test/reload.ps1
@@ -1,0 +1,15 @@
+if (Get-SecretVault 'LastPass.Tests' -ErrorAction Ignore) {
+    Unregister-SecretVault 'LastPass.Tests'
+}
+
+$modules = 'SecretManagement.LastPass','Microsoft.PowerShell.SecretStore','Microsoft.PowerShell.SecretManagement'
+
+foreach ($module in $modules) {
+    if (Get-Module $module) {
+        Remove-Module $module -Force
+    }
+}
+
+Register-SecretVault (Join-Path $PSScriptRoot '..' 'SecretManagement.LastPass.psd1') -Name 'LastPass.Tests'
+
+Import-Module (Join-Path $PSScriptRoot '..' 'SecretManagement.LastPass.psd1') -Force


### PR DESCRIPTION
This fixes a couple issues I've found on macOS:

1. Setting and then retrieving a secret didn't work until after a few ms... apparently this was because secrets that are not "saved to lastpass" yet have a date time in the output of `lpass ls`. I modified the regex to include this.
2. Even though we were routing errors in the error stream to `/dev/null` I still would see the text `Error: Can't find the account` (or something like that). To fix that, I routed all streams to output and handled errors accordingly
3. `$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secret.$k)` etc... didn't work on macOS... like it would only return the first character of the secret... very odd... to fix this I use `[System.Net.NetworkCredential]::new("", $Secret.NoteType).Password`

This also adds a couple tests I stole from Steve's KeyChain vault... some are disabled for now. But we can bring those back in time...

@itfranck interested in reviewing?