### PR TITLE
Buffix/ignore errors elegantly

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -36,12 +36,11 @@ $DefaultNoteTypeMap = @{
     'Wi-Fi Password'    = 'wifi'
 } 
 
-  $lpassMessage = @{
-        AccountNotFound = 'Error: Could not find specified account(s).'
-        LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with `lpass login`.'
-        MultipleMatches = 'Multiple matches found.'
-    }
-
+$lpassMessage = @{
+    AccountNotFound = 'Error: Could not find specified account(s).'
+    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with `lpass login`.'
+    MultipleMatches = 'Multiple matches found.'
+}
 # These fields need special consideration when working with secrets.
 # Language / NoteType are fields that are part of any custom notes and always appear last (before Notes)
 #Notes field can appear in any secrets and is always the last field. It is also the only multiline field.
@@ -215,7 +214,7 @@ function Set-Secret
             $sb.AppendLine("Notes: `n$($Secret.Notes)") | Out-Null
         }
     } 
-    
+
     try {
         $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
         # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -51,6 +51,10 @@ function Invoke-lpass {
         [object]
         $InputObject
     )
+    $IgnoreErrors = $null
+    if ($ErrorActionPreference -eq 'SilentlyContinue') {
+        $IgnoreErrors = '2>&1'
+    }
 
     $lpassCommand = if ($null -ne $AdditionalParameters.lpassCommand){$AdditionalParameters.lpassCommand} else {''}
     $lpassPath = if ($null -ne $AdditionalParameters.lpassPath){"`"$($AdditionalParameters.lpassPath)`""} else {'lpass'}
@@ -58,14 +62,14 @@ function Invoke-lpass {
     
     if ($lpassCommand -ne '' -and ((& "$lpassCommand" $lpassPath --version ) -like 'LastPass CLI*') ) {
         if ($InputObject) {
-            return $InputObject | & "$lpassCommand" $lpassPath @Arguments *>&1
+            return $InputObject | & "$lpassCommand" $lpassPath @Arguments $IgnoreErrors
         }
-        return   & "$lpassCommand" $lpassPath @Arguments *>&1
+        return   & "$lpassCommand" $lpassPath @Arguments $IgnoreErrors
      } elseif (Get-Command $lpassPath) {
         if ($InputObject) {
-            return  $InputObject | & $lpassPath @Arguments *>&1
+            return  $InputObject | & $lpassPath @Arguments $IgnoreErrors
         }
-        return & $lpassPath @Arguments *>&1
+        return & $lpassPath @Arguments $IgnoreErrors
     }
 
     throw "lpass executable not found or installed."

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -234,7 +234,7 @@ function Set-Secret
                     return $false
                     break
                 }
-                { Default } {
+                Default {
                     $SecretExists = $true
                 }
             }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -9,11 +9,11 @@ using namespace Microsoft.PowerShell.SecretManagement
 # 4. The username of the secret
 $lsLongOutput = "(\d\d\d\d-\d\d-\d\d \d\d:\d\d)? *((.*) \[id: \d*\]) \[username: (.*)\]"
 
-    # Custom notes in lpass CLI are a bit of a mess.
-    # For default types
-    # Get operation will return the value
-    # Set operation will only accept the key
-    # This is to convert value obtained from Get when doing a Set. 
+# Custom notes in lpass CLI are a bit of a mess.
+# For default types
+# Get operation will return the value
+# Set operation will only accept the key
+# This is to convert value obtained from Get when doing a Set. 
 $DefaultNoteTypeMap = @{
     'Address'           = 'address'
     # 'amex' = ''       # Possibly deprecated            

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -210,7 +210,7 @@ function Set-Secret
     } 
     
     try {
-        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name
+        $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
         # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
         $SecretExists = $null -ne $res -and $res.ToString() -ne "Error: Could not find specified account(s)."
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -218,24 +218,25 @@ function Set-Secret
     try {
         $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
         # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
-        switch ($res) {
-            $null {
-                # It should never happen... Try to proceed anyway ?
-                Write-Warning "Querying the secret $Name produced an unexpected result of `$Null"
-                $SecretExists = $false   
-                break
-            }
-            $lpassMessage.AccountNotFound {
-                $SecretExists = $false
-                break
-            }
-            $lpassMessage.LoggedOut {
-                Write-Error $lpassMessage.LoggedOut 
-                return $false
-                break
-            }
-            {Default} {
-                $SecretExists = $true
+        if ($null -eq $res) {
+            # This should never ever happen... 
+            Write-Warning "Querying the secret $Name produced an unexpected result of `$Null"
+            $SecretExists = $false   
+        }
+        else {
+            switch ($res.ToString()) {
+                $lpassMessage.AccountNotFound {
+                    $SecretExists = $false
+                    break
+                }
+                $lpassMessage.LoggedOut {
+                    Write-Error $lpassMessage.LoggedOut 
+                    return $false
+                    break
+                }
+                { Default } {
+                    $SecretExists = $true
+                }
             }
         }
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -163,7 +163,6 @@ function Set-Secret
         [Parameter(ValueFromPipelineByPropertyName)]
         [hashtable] $AdditionalParameters
     )
-    # -eq $true is used since the value will be null before Preview 5, which is equivalent to -verbose:$true
     if ($AdditionalParameters.Verbose) {
         $VerbosePreference = "Continue"
     }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -225,13 +225,13 @@ function Set-Secret
                 $SecretExists = $false   
                 break
             }
+            $lpassMessage.AccountNotFound {
+                $SecretExists = $false
+                break
+            }
             $lpassMessage.LoggedOut {
                 Write-Error $lpassMessage.LoggedOut 
                 return $false
-                break
-            }
-            $lpassMessage.AccountNotFound {
-                $SecretExists = $false
                 break
             }
             {Default} {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -214,7 +214,7 @@ function Set-Secret
             $sb.AppendLine("Notes: `n$($Secret.Notes)") | Out-Null
         }
     } 
-
+    
     try {
         $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
         # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord


### PR DESCRIPTION
This seems to be an elegant solution to the problem and as far as I can tell, it work well. 

I tested
- While logged out : I received the expected error
- Setting a secret, I did not get any "Account not found" message when adding a new secret.

I can test the prompt window in 1h once I get disconnected. 