### PR TITLE
Additional functions - convenience and more 

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psd1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psd1
@@ -1,5 +1,5 @@
 @{
     ModuleVersion = '1.0'
     RootModule = 'SecretManagement.LastPass.Extension.psm1'
-    FunctionsToExport = @('Set-Secret','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault')
+    FunctionsToExport = @('Set-Secret','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault','Invoke-lpass')
 }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -41,7 +41,7 @@ $DefaultNoteTypeMap = @{
 $lpassMessage = @{
     AccountNotFound = 'Error: Could not find specified account(s).'
     # Need to use wildcard since the path of lpass could be different
-    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with*'
+    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with Connect-LastPass'
     MultipleMatches = 'Multiple matches found.'
 }
 
@@ -61,8 +61,13 @@ function Invoke-lpass {
 
         [Parameter(ValueFromPipeline)]
         [object]
-        $InputObject
+        $InputObject,
+        #Only for root module functions
+        [hashtable]$VaultParams
     )
+    # Command from the root module do not contain $AdditionalParameters
+    if ($null -ne $VaultParams){$AdditionalParameters = $VaultParams}
+
     $lpassCommand = if ($null -ne $AdditionalParameters.lpassCommand) { $AdditionalParameters.lpassCommand } else { '' }
     $lpassPath = if ($null -ne $AdditionalParameters.lpassPath) { "`"$($AdditionalParameters.lpassPath)`"" } else { 'lpass' }
 

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -8,6 +8,9 @@
 
 @{
 
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'SecretManagement.LastPass.psm1'
+
     # Version number of this module.
     ModuleVersion     = '0.2.0'
 

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -48,7 +48,7 @@
     NestedModules     = './SecretManagement.LastPass.Extension'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @()
+    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass','Register-LastPassVault','Unregister-LastPassVault')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+using namespace Microsoft.PowerShell.SecretManagement
+
+$ModuleName = 'SecretManagement.LastPass'
+function Connect-LastPass {
+    [CmdletBinding()]
+    param (
+        [String]$VaultName,
+        [String]$User,
+        [Switch]$Trust
+    )
+    $Arguments = [System.Collections.Generic.List[String]]@('login')
+    if ($trust) {$Arguments.Add('--trust')}
+    $Arguments.Add($User)
+    $VaultParams = Get-VaultParams -VaultName $VaultName
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
+}
+
+function Disconnect-LastPass {
+    [CmdletBinding()]
+    param (
+        [String]$VaultName
+    )
+    $Arguments = [System.Collections.Generic.List[String]]@('logout')
+    $VaultParams = Get-VaultParams -VaultName $VaultName
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
+}
+
+function Register-LastPassVault {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [String]$VaultName,
+        [String]$Command,
+        [String]$Path
+    )
+ 
+    $Params = @{
+        ModuleName = 'SecretManagement.LastPass'
+        Name = $VaultName
+        VaultParameters = @{}
+    }
+
+    if ('' -ne $Command) { $Params.VaultParameters.Add('lpassCommand', $Command) }
+    if ('' -ne $Path) { $Params.VaultParameters.Add('lpassPath', $Path) }
+
+    Register-SecretVault @Params
+}
+function Unregister-LastPassVault {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [String]$VaultName
+    )
+    Unregister-SecretVault -Name $VaultName 
+}
+
+Function Get-VaultParams($VaultName) {
+    if ([String]::IsNullOrEmpty($VaultName)){ 
+            $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName
+            switch ($AllVaults.count) {
+                0 { Throw "At least 1 vault implementing $ModuleName must be registered.";break }
+                1 { return $AllVaults[0].VaultParameters }
+                Default { Throw "`$VaultName argument must be provided when multiple vault implementing $ModuleName exists $($AllVaults.Name -join ',')" }
+            }
+    }
+
+    $VaultParams = (Get-SecretVault -Name $VaultName -ErrorAction Stop).VaultParameters
+    return $VaultParams
+
+}

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -70,3 +70,19 @@ Function Get-VaultParams($VaultName) {
     return $VaultParams
 
 }
+
+#region VaultNameArgumentCompleter
+$VaultNameArgcompleter = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    return (Get-SecretVault -Name "*$wordToComplete*") | Select-Object -ExpandProperty Name
+}
+$VaultNameLPArgcompleter = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    return Get-SecretVault -Name "*$wordToComplete*" | Where-Object ModuleName -eq $ModuleName | Select-Object -ExpandProperty Name
+}
+
+
+Register-ArgumentCompleter -CommandName 'Register-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameArgcompleter
+Register-ArgumentCompleter -CommandName 'Unregister-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameLPArgcompleter
+#endregion
+

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -56,7 +56,8 @@ function Unregister-LastPassVault {
     Unregister-SecretVault -Name $VaultName 
 }
 
-Function Get-VaultParams($VaultName) {
+Function Get-VaultParams {
+    Param($VaultName)
     if ([String]::IsNullOrEmpty($VaultName)){ 
             $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName
             switch ($AllVaults.count) {


### PR DESCRIPTION
How do you feel exposing additional functions ? 

Connect / Disconnect (manage connecting to lpass) 
By exposing the Connect function, the user do not have to know anything about the cli syntax at all... 

Register / Unregister
Register-LastPassVault is more complete than Register-SecretVault since we can have specific parameters for command / path without having to go check the doc. 

eg: 
```
Register-LassPassVault -VaultName MyVault -Command wsl
```
instead of 
```
  $Params = @{
        ModuleName = 'SecretManagement.LastPass'
        Name = 'MyVault'
        VaultParameters = @{lpassCommand = wsl}
    }

Register-SecretVault @Params
```


This open the door to adding more CLI element into the module later on.
Good 👍 or meh 👎 ? 

If good, I'll edit the Readme to take that into account. 
