### PR TITLE
Additional functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ Unregister a SecretVault of type SecretManagement.LastPass
 Name of the vault to be unregistered.
 
 ### Connect-LastPass
-Initiate connection to the LastPass account. 
+Connect the user to LastPass account.
 
 #### Parameters
 ##### Vault
-Name of the vault to connect against.
+Name of the vault to connect to.
 
 ##### Username
 Username to connect with.
@@ -157,9 +157,11 @@ Username to connect with.
 Cause subsquent logins to not require multifactor authentication.
 
 ##### [Switch] StayConnected
-Save the LastPass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
+Save the LastPass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. This operation will prompt the user.
 
 ### Disconnect-LastPass
+Disconnect the user to LastPass account.
+
 #### Parameters
 
 ##### Vault

--- a/README.md
+++ b/README.md
@@ -115,51 +115,51 @@ Register-SecretVault -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass
 By default, regular credentials are returned as string (for notes) and PSCredential (for credentials) 
 Setting this parameter to **Detailed** will always return a hashtable. Effectively, this mean that the URL / Notes parameter of the regular credential will be exposed. 
 
-### Additional Functions
+## Additional Functions
 
-#### Register-LastPassVault
+### Register-LastPassVault
 
 Register a SecretVault of type SecretManagement.LastPass
 
-##### Parameters
-###### VaultName
+#### Parameters
+##### VaultName
 Name of the vault to be registered. If no name is provided, **SecretManagement.LastPass** will be used.
 
-###### Command
+##### Command
 Command that will call lpass CLI. This is mainly for Windows user, that need to use wsl to use the CLI.
 
-###### Path
+##### Path
 Custom path to the lpass CLI
 
 
-#### Unregister-LastPassVault
+### Unregister-LastPassVault
 
 Unregister a SecretVault of type SecretManagement.LastPass
 
-##### Parameters
-###### VaultName
+#### Parameters
+##### VaultName
 Name of the vault to be unregistered.
 
-#### Connect-LastPass
+### Connect-LastPass
 Initiate connection to the Last Pass account. 
 
-##### Parameters
-###### VaultName
+#### Parameters
+##### VaultName
 Name of the vault to connect against.
 
-###### Username
+##### Username
 Username to connect with.
 
-###### Trust
+##### Trust
 The trust switch will cause subsquent logins to not require multifactor authentication.
 
-#### Disconnect-LastPass
-##### Parameters
+### Disconnect-LastPass
+#### Parameters
 
-###### VaultName
+##### VaultName
 Name of the vault to perform the disconnect against.
 
-### Extension Limitations
+## Extension Limitations
 
 Some limitations exist on this module, inherent to the CLI they are based on. 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ commands!
 
 The module also have the following vault parameter, that can be provided at registration.
 
-#### [switch] wsl
+#### [switch] Wsl
 
 Call lpass CLI through Windows Subsystem for Linux (WSL). 
 
@@ -83,7 +83,7 @@ Call lpass CLI through Windows Subsystem for Linux (WSL).
 
 ```pwsh
 # Dedicated function
-Register-LastPassVault -Vault 'MyVault' -wsl
+Register-LastPassVault -Vault 'MyVault' -Wsl
 
 # Using SecretManagement interface
 Register-SecretVault  -Vault 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
@@ -125,7 +125,7 @@ Register a SecretVault of type SecretManagement.LastPass
 ##### Vault
 Name of the vault to be registered. If no name is provided, **SecretManagement.LastPass** will be used.
 
-##### [switch] wsl
+##### [switch] Wsl
 Call lpass CLI through Windows Subsystem for Linux (WSL). 
 
 ##### [switch] Detailed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Name of the vault to be registered. If no name is provided, **SecretManagement.L
 ##### [switch] wsl
 Call lpass CLI through Windows Subsystem for Linux (WSL). 
 
+##### [switch] Detailed
+All records will be returned as hashtable. Notes and regular credentials. In turn, Notes and URL field from the credential will also be returned.
+
 ##### Path
 Custom path to the lpass CLI
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ This parameter allow the use of a custom command to be called before lpass (such
 * Working with WSL
 
 ```pwsh
-Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+# Dedicated function
+Register-LastPassVault -VaultName 'MyVault' -Command wsl
+
+# Using SecretManagement interface
+Register-SecretVault  -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     lpassCommand = 'wsl'
 }
 ```
@@ -97,7 +101,11 @@ This parameter will allow to provide a custom lpass path location for the CLI
 * Specifying a path
 
 ```pwsh
-Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+# Dedicated function
+Register-LastPassVault -VaultName 'MyVault' -Path "/usr/bin/some path/to/lpass"
+
+# Using SecretManagement interface
+Register-SecretVault -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     lpassPath = "/usr/bin/some path/to/lpass"
 }
 ```
@@ -107,7 +115,51 @@ Register-SecretVault -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
 By default, regular credentials are returned as string (for notes) and PSCredential (for credentials) 
 Setting this parameter to **Detailed** will always return a hashtable. Effectively, this mean that the URL / Notes parameter of the regular credential will be exposed. 
 
-### Limitations
+### Additional Functions
+
+#### Register-LastPassVault
+
+Register a SecretVault of type SecretManagement.LastPass
+
+##### Parameters
+###### VaultName
+Name of the vault to be registered. If no name is provided, **SecretManagement.LastPass** will be used.
+
+###### Command
+Command that will call lpass CLI. This is mainly for Windows user, that need to use wsl to use the CLI.
+
+###### Path
+Custom path to the lpass CLI
+
+
+#### Unregister-LastPassVault
+
+Unregister a SecretVault of type SecretManagement.LastPass
+
+##### Parameters
+###### VaultName
+Name of the vault to be unregistered.
+
+#### Connect-LastPass
+Initiate connection to the Last Pass account. 
+
+##### Parameters
+###### VaultName
+Name of the vault to connect against.
+
+###### Username
+Username to connect with.
+
+###### Trust
+The trust switch will cause subsquent logins to not require multifactor authentication.
+
+#### Disconnect-LastPass
+##### Parameters
+
+###### VaultName
+Name of the vault to perform the disconnect against.
+
+### Extension Limitations
 
 Some limitations exist on this module, inherent to the CLI they are based on. 
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ Call lpass CLI through Windows Subsystem for Linux (WSL).
 
 ```pwsh
 # Dedicated function
-Register-LastPassVault -VaultName 'MyVault' -wsl
+Register-LastPassVault -Vault 'MyVault' -wsl
 
 # Using SecretManagement interface
-Register-SecretVault  -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+Register-SecretVault  -Vault 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     wsl = $true
 }
 ```
@@ -102,10 +102,10 @@ Allow to provide a custom lpass path location for the CLI
 
 ```pwsh
 # Dedicated function
-Register-LastPassVault -VaultName 'MyVault' -Path "/usr/bin/some path/to/lpass"
+Register-LastPassVault -Vault 'MyVault' -Path "/usr/bin/some path/to/lpass"
 
 # Using SecretManagement interface
-Register-SecretVault -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
+Register-SecretVault -Vault 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
     lpassPath = "/usr/bin/some path/to/lpass"
 }
 ```
@@ -122,7 +122,7 @@ Setting this parameter to **Detailed** will always return a hashtable. Effective
 Register a SecretVault of type SecretManagement.LastPass
 
 #### Parameters
-##### VaultName
+##### Vault
 Name of the vault to be registered. If no name is provided, **SecretManagement.LastPass** will be used.
 
 ##### [switch] wsl
@@ -137,14 +137,14 @@ Custom path to the lpass CLI
 Unregister a SecretVault of type SecretManagement.LastPass
 
 #### Parameters
-##### VaultName
+##### Vault
 Name of the vault to be unregistered.
 
 ### Connect-LastPass
 Initiate connection to the LastPass account. 
 
 #### Parameters
-##### VaultName
+##### Vault
 Name of the vault to connect against.
 
 ##### Username
@@ -159,7 +159,7 @@ Save the LastPass decryption key on the hard drive so re-entering password once 
 ### Disconnect-LastPass
 #### Parameters
 
-##### VaultName
+##### Vault
 Name of the vault to perform the disconnect against.
 
 
@@ -167,7 +167,7 @@ Name of the vault to perform the disconnect against.
 Forces a synchronization of the local cache with the LastPass servers, and does not exit until the local cache is synchronized or until an error occurs
 #### Parameters
 
-##### VaultName
+##### Vault
 Name of the vault
 
 ## Extension Limitations

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Username to connect with.
 ##### Trust
 The trust switch will cause subsquent logins to not require multifactor authentication.
 
+##### StayConnected
+The StayConnected switch will save the Last Pass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
+
 ### Disconnect-LastPass
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Unregister a SecretVault of type SecretManagement.LastPass
 Name of the vault to be unregistered.
 
 ### Connect-LastPass
-Initiate connection to the Last Pass account. 
+Initiate connection to the LastPass account. 
 
 #### Parameters
 ##### VaultName
@@ -154,13 +154,21 @@ Username to connect with.
 Cause subsquent logins to not require multifactor authentication.
 
 ##### [Switch] StayConnected
-Save the Last Pass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
+Save the LastPass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
 
 ### Disconnect-LastPass
 #### Parameters
 
 ##### VaultName
 Name of the vault to perform the disconnect against.
+
+
+### Sync-LastPassVault
+Forces a synchronization of the local cache with the LastPass servers, and does not exit until the local cache is synchronized or until an error occurs
+#### Parameters
+
+##### VaultName
+Name of the vault
 
 ## Extension Limitations
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ commands!
 
 The module also have the following vault parameter, that can be provided at registration.
 
-#### lpassCommand
+#### [switch] wsl
 
-This parameter allow the use of a custom command to be called before lpass (such as, but not limited to, wsl)
+Call lpass CLI through Windows Subsystem for Linux (WSL). 
 
 ##### Examples
 
@@ -83,18 +83,18 @@ This parameter allow the use of a custom command to be called before lpass (such
 
 ```pwsh
 # Dedicated function
-Register-LastPassVault -VaultName 'MyVault' -Command wsl
+Register-LastPassVault -VaultName 'MyVault' -wsl
 
 # Using SecretManagement interface
 Register-SecretVault  -VaultName 'MyVault' -ModuleName 'SecretManagement.LastPass' -VaultParameters @{
-    lpassCommand = 'wsl'
+    wsl = $true
 }
 ```
 
 
 #### lpassPath
 
-This parameter will allow to provide a custom lpass path location for the CLI
+Allow to provide a custom lpass path location for the CLI
 
 ##### Examples
 
@@ -125,8 +125,8 @@ Register a SecretVault of type SecretManagement.LastPass
 ##### VaultName
 Name of the vault to be registered. If no name is provided, **SecretManagement.LastPass** will be used.
 
-##### Command
-Command that will call lpass CLI. This is mainly for Windows user, that need to use wsl to use the CLI.
+##### [switch] wsl
+Call lpass CLI through Windows Subsystem for Linux (WSL). 
 
 ##### Path
 Custom path to the lpass CLI
@@ -150,11 +150,11 @@ Name of the vault to connect against.
 ##### Username
 Username to connect with.
 
-##### Trust
-The trust switch will cause subsquent logins to not require multifactor authentication.
+##### [Switch] Trust
+Cause subsquent logins to not require multifactor authentication.
 
-##### StayConnected
-The StayConnected switch will save the Last Pass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
+##### [Switch] StayConnected
+Save the Last Pass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. It must be used along with the Force switch parameter. 
 
 ### Disconnect-LastPass
 #### Parameters

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psd1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psd1
@@ -1,5 +1,5 @@
 @{
     ModuleVersion = '1.0'
     RootModule = 'SecretManagement.LastPass.Extension.psm1'
-    FunctionsToExport = @('Set-Secret','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault')
+    FunctionsToExport = @('Set-Secret','Get-Secret','Remove-Secret','Get-SecretInfo','Test-SecretVault','Invoke-lpass')
 }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -41,7 +41,7 @@ $DefaultNoteTypeMap = @{
 $lpassMessage = @{
     AccountNotFound = 'Error: Could not find specified account(s).'
     # Need to use wildcard since the path of lpass could be different
-    LoggedOut       = 'Error: Could not find decryption key. Perhaps you need to login with Connect-LastPass'
+    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with Connect-LastPass'
     MultipleMatches = 'Multiple matches found.'
 }
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -41,7 +41,7 @@ $DefaultNoteTypeMap = @{
 $lpassMessage = @{
     AccountNotFound = 'Error: Could not find specified account(s).'
     # Need to use wildcard since the path of lpass could be different
-    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with Connect-LastPass'
+    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with*'
     MultipleMatches = 'Multiple matches found.'
 }
 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -41,7 +41,7 @@ $DefaultNoteTypeMap = @{
 $lpassMessage = @{
     AccountNotFound = 'Error: Could not find specified account(s).'
     # Need to use wildcard since the path of lpass could be different
-    LoggedOut = 'Error: Could not find decryption key. Perhaps you need to login with*'
+    LoggedOut       = 'Error: Could not find decryption key. Perhaps you need to login with Connect-LastPass'
     MultipleMatches = 'Multiple matches found.'
 }
 
@@ -61,8 +61,13 @@ function Invoke-lpass {
 
         [Parameter(ValueFromPipeline)]
         [object]
-        $InputObject
+        $InputObject,
+        #Only for root module functions
+        [hashtable]$VaultParams
     )
+     # Command from the root module do not contain $AdditionalParameters
+    if ($null -ne $VaultParams) { $AdditionalParameters = $VaultParams }
+    
     $lpassCommand = if ($null -ne $AdditionalParameters.lpassCommand) { $AdditionalParameters.lpassCommand } else { '' }
     $lpassPath = if ($null -ne $AdditionalParameters.lpassPath) { "`"$($AdditionalParameters.lpassPath)`"" } else { 'lpass' }
 

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -50,7 +50,7 @@
     NestedModules     = './SecretManagement.LastPass.Extension'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault')
+    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault','Sync-LastPassVault')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -7,6 +7,8 @@
 #
 
 @{
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'SecretManagement.LastPass.psm1'
 
     # Version number of this module.
     ModuleVersion     = '0.2.0'
@@ -48,7 +50,7 @@
     NestedModules     = './SecretManagement.LastPass.Extension'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @()
+    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -87,6 +87,9 @@ function Sync-LastPassVault {
 function Get-VaultParams {
     Param($Vault)
     if ([String]::IsNullOrEmpty($Vault)) { 
+        $DefaultVault = Get-SecretVault -Name $ModuleName -ErrorAction SilentlyContinue
+        if ($null -ne $DefaultVault) { return $DefaultVault.VaultParameters }
+
         $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName
         switch ($AllVaults.count) {
             0 { Throw $ErrorMessages.GetVaultParams0; break }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -3,15 +3,27 @@
 using namespace Microsoft.PowerShell.SecretManagement
 
 $ModuleName = 'SecretManagement.LastPass'
+
+$Messages = @{
+    StayConnectedForceSwitchMissing = 'StayConnected is a sensitive operation that save the LastPass decryption key on your hard drive. If you want to proceed, reissue the command specifying the force parameter.'
+}
+
 function Connect-LastPass {
     [CmdletBinding()]
     param (
         [String]$VaultName,
         [String]$User,
-        [Switch]$Trust
+        [Switch]$Trust,
+        [Switch]$StayConnected,
+        [Switch]$Force 
     )
     $Arguments = [System.Collections.Generic.List[String]]@('login')
     if ($trust) { $Arguments.Add('--trust') }
+    if ($StayConnected) { 
+        if (! $Force) { Throw [System.Management.Automation.PSArgumentException] $Messages.StayConnectedForceSwitchMissing }
+        $Arguments.Add('--plaintext-key') 
+        $Arguments.Add('--force')
+    }
     $Arguments.Add($User)
     $VaultParams = Get-VaultParams -VaultName $VaultName
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -1,0 +1,88 @@
+﻿# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+using namespace Microsoft.PowerShell.SecretManagement
+
+$ModuleName = 'SecretManagement.LastPass'
+function Connect-LastPass {
+    [CmdletBinding()]
+    param (
+        [String]$VaultName,
+        [String]$User,
+        [Switch]$Trust
+    )
+    $Arguments = [System.Collections.Generic.List[String]]@('login')
+    if ($trust) { $Arguments.Add('--trust') }
+    $Arguments.Add($User)
+    $VaultParams = Get-VaultParams -VaultName $VaultName
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
+}
+
+function Disconnect-LastPass {
+    [CmdletBinding()]
+    param (
+        [String]$VaultName
+    )
+    $Arguments = [System.Collections.Generic.List[String]]@('logout')
+    $VaultParams = Get-VaultParams -VaultName $VaultName
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
+}
+
+function Register-LastPassVault {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [String]$VaultName,
+        [String]$Command,
+        [String]$Path
+    )
+ 
+    $Params = @{
+        ModuleName      = 'SecretManagement.LastPass'
+        Name            = $VaultName
+        VaultParameters = @{}
+    }
+
+    if ('' -ne $Command) { $Params.VaultParameters.Add('lpassCommand', $Command) }
+    if ('' -ne $Path) { $Params.VaultParameters.Add('lpassPath', $Path) }
+
+    Register-SecretVault @Params
+}
+function Unregister-LastPassVault {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [String]$VaultName
+    )
+    Unregister-SecretVault -Name $VaultName 
+}
+
+Function Get-VaultParams {
+    Param($VaultName)
+    if ([String]::IsNullOrEmpty($VaultName)) { 
+        $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName
+        switch ($AllVaults.count) {
+            0 { Throw "At least 1 vault implementing $ModuleName must be registered."; break }
+            1 { return $AllVaults[0].VaultParameters }
+            Default { Throw "`$VaultName argument must be provided when multiple vault implementing $ModuleName exists $($AllVaults.Name -join ',')" }
+        }
+    }
+
+    $VaultParams = (Get-SecretVault -Name $VaultName -ErrorAction Stop).VaultParameters
+    return $VaultParams
+
+}
+
+#region VaultNameArgumentCompleter
+$VaultNameArgcompleter = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    return (Get-SecretVault -Name "*$wordToComplete*") | Select-Object -ExpandProperty Name
+}
+$VaultNameLPArgcompleter = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    return Get-SecretVault -Name "*$wordToComplete*" | Where-Object ModuleName -eq $ModuleName | Select-Object -ExpandProperty Name
+}
+
+
+Register-ArgumentCompleter -CommandName 'Register-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameArgcompleter
+Register-ArgumentCompleter -CommandName 'Unregister-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameLPArgcompleter
+#endregion

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -10,7 +10,38 @@ $ErrorMessages = @{
     GetVaultParamsMany_1            = "`$Vault argument must be provided when multiple vault implementing $ModuleName exists: {0}"
     Unregister_NotLpass_1           = "The specified vault is not a $ModuleName vault (VaultType: {0}"
 }
+<#
+.SYNOPSIS
+Connect the user to LastPass account.
 
+.DESCRIPTION
+Connect the user to LastPass account.
+
+.PARAMETER Vault
+Name of the vault to connect to.
+
+.PARAMETER User
+Username to connect with.
+
+.PARAMETER Trust
+Cause subsquent logins to not require multifactor authentication.
+
+.PARAMETER StayConnected
+Save the LastPass decryption key on the hard drive so re-entering password once the connection window close is not required anymore. 
+This operation will prompt the user.
+
+.PARAMETER Force
+Force switch.
+
+.EXAMPLE
+PS> Connect-LastPass -Vault MyVault -User User@example.com -Trust
+
+Connect the user User@example.com and disable future MFA prompt.
+.EXAMPLE
+PS> Connect-LastPass -Vault MyVault -User User@example.com -StayConnected -Force
+
+Connect the user User@example.com and save the decryption key to disk. Password to connect will never be asked again.
+#>
 function Connect-LastPass {
     [CmdletBinding(
         SupportsShouldProcess,
@@ -38,6 +69,19 @@ function Connect-LastPass {
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }
 
+<#
+.SYNOPSIS
+Disconnect the user to LastPass account.
+
+.DESCRIPTION
+Disconnect the user to LastPass account.
+
+.PARAMETER Vault
+Name of the vault to perform the disconnect against.
+
+.EXAMPLE
+PS> Disconnect-LastPass
+#>
 function Disconnect-LastPass {
     [CmdletBinding()]
     param (
@@ -48,6 +92,35 @@ function Disconnect-LastPass {
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }
 
+<#
+.SYNOPSIS
+Register a SecretVault of type SecretManagement.LastPass
+
+.DESCRIPTION
+Register a SecretVault of type SecretManagement.LastPass
+
+.PARAMETER Vault
+Name of the vault to be registered. If no name is provided, SecretManagement.LastPass will be used.
+
+.PARAMETER Wsl
+Call lpass CLI through Windows Subsystem for Linux (WSL).
+
+.PARAMETER Detailed
+All records will be returned as hashtable. Notes and regular credentials. In turn, Notes and URL field from the credential will also be returned.
+
+.PARAMETER Path
+Custom path to the lpass CLI.
+
+.EXAMPLE
+PS> Register-LastPassVault
+
+Register a vault called SecretManagement.LastPass
+
+.EXAMPLE
+PS> Register-LastPassVault -Vault MyVault -Wsl -Detailed
+
+Register a vault called MyVault that will be called through wsl and work with the Detailed output type. 
+#>
 function Register-LastPassVault {
     [CmdletBinding()]
     param (
@@ -71,6 +144,22 @@ function Register-LastPassVault {
 
     Register-SecretVault @Params
 }
+
+<#
+.SYNOPSIS
+Unregister a SecretVault of type SecretManagement.LastPass.
+
+.DESCRIPTION
+Unregister a SecretVault of type SecretManagement.LastPass.
+
+.PARAMETER Vault
+Name of the vault to be unregistered.
+
+.EXAMPLE
+PS> Unregister-LastPassVault -Vault MyVault
+
+Unregister the vault 'MyVault'.
+#>
 function Unregister-LastPassVault {
     [CmdletBinding()]
     param (
@@ -84,6 +173,19 @@ function Unregister-LastPassVault {
     Unregister-SecretVault @Params 
 }
 
+<#
+.SYNOPSIS
+Synchronize the local cache with the LastPass servers.
+
+.DESCRIPTION
+Synchronize the local cache with the LastPass servers and does not exit until the local cache is synchronized or until an error occurs
+
+.PARAMETER Vault
+Name of the vault
+
+.EXAMPLE
+Sync-LastPass -Vault MyVault
+#>
 function Sync-LastPassVault {
     [CmdletBinding()]
     param ([String]$Vault)

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -79,7 +79,7 @@ function Sync-LastPassVault {
     [CmdletBinding()]
     param ([String]$VaultName)
     $VaultParams = Get-VaultParams -VaultName $VaultName
-    Invoke-lpass -Arguments 'Sync' -VaultParams $VaultParams
+    Invoke-lpass -Arguments 'Sync','--now' -VaultParams $VaultParams
 }
 Function Get-VaultParams {
     Param($VaultName)

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -55,12 +55,14 @@ function Register-LastPassVault {
     $Params = @{
         ModuleName      = 'SecretManagement.LastPass'
         Name            = if ('' -ne $Vault) {$Vault} else {$ModuleName}
-        VaultParameters = @{}
+        Verbose         = $VerbosePreference -eq 'Continue'
+        VaultParameters = @{
+            wsl         = $Wsl.IsPresent
+            outputType  = if ($Detailed) { 'Detailed' } else { 'Default' }
+        }
     }
-    if ($Wsl -eq $true) { $Params.VaultParameters.Add('wsl', $true) }
+
     if ($Path -ne '') { $Params.VaultParameters.Add('lpassPath', $Path) }
-    if ($Detailed -eq $true) { $Params.VaultParameters.Add('outputType','Detailed') }
-    if ($VerbosePreference -eq 'Continue') {$Params.add('Verbose',$true)}
 
     Register-SecretVault @Params
 }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -68,7 +68,7 @@ function Unregister-LastPassVault {
         [Parameter(Mandatory = $true)]
         [String]$VaultName
     )
-    $Params = @{Name = if ('' -ne $VaultName) { $VaultName } else { $ModuleName }}
+    $Params = @{VaultName = if ('' -ne $VaultName) { $VaultName } else { $ModuleName } }
     if ($VerbosePreference -eq 'Continue') {$Params.Add('Verbose',$true)}
     
     $Vault = Get-SecretVault -Name $params.VaultName -ErrorAction Stop

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -165,8 +165,10 @@ function Unregister-LastPassVault {
     param (
         [String]$Vault
     )
-    $Params = @{Name = if ('' -ne $Vault) { $Vault } else { $ModuleName } }
-    if ($VerbosePreference -eq 'Continue') {$Params.Add('Verbose',$true)}
+    $Params = @{
+        Name = if ('' -ne $Vault) { $Vault } else { $ModuleName }
+        Verbose = $VerbosePreference -eq 'Continue'
+    }
     
     $Vault = Get-SecretVault -Name $params.Name -ErrorAction Stop
     if ($Vault.ModuleName -ne $ModuleName) { Throw $ErrorMessages.Unregister_NotLpass_1 -f $Vault.ModuleName }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -47,7 +47,7 @@ function Register-LastPassVault {
     [CmdletBinding()]
     param (
         [String]$VaultName,
-        [String]$Command,
+        [switch]$wsl,
         [String]$Path
     )
 
@@ -56,8 +56,8 @@ function Register-LastPassVault {
         Name            = if ('' -ne $VaultName) {$VaultName} else {$ModuleName}
         VaultParameters = @{}
     }
-    if ('' -ne $Command) { $Params.VaultParameters.Add('lpassCommand', $Command) }
-    if ('' -ne $Path) { $Params.VaultParameters.Add('lpassPath', $Path) }
+    if ($wsl -eq $true) { $Params.VaultParameters.Add('wsl', $true) }
+    if ($Path -ne '') { $Params.VaultParameters.Add('lpassPath', $Path) }
     if ($VerbosePreference -eq 'Continue') {$Params.add('Verbose',$true)}
 
     Register-SecretVault @Params

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -73,7 +73,7 @@ function Unregister-LastPassVault {
     if ($VerbosePreference -eq 'Continue') {$Params.Add('Verbose',$true)}
     
     $Vault = Get-SecretVault -Name $params.Name -ErrorAction Stop
-    if ($Vault.ModuleName -ne $ModuleName) { Throw $ErrorMessages.Unregister_NotLpass_1 -f $Vault.ModuleName}
+    if ($Vault.ModuleName -ne $ModuleName) { Throw $ErrorMessages.Unregister_NotLpass_1 -f $Vault.ModuleName }
     Unregister-SecretVault @Params 
 }
 

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -29,7 +29,7 @@ function Connect-LastPass {
         $Arguments.Add('--force')
     }
     $Arguments.Add($User)
-    $VaultParams = Get-VaultParams -VaultName $Vault
+    $VaultParams = Get-VaultParams -Vault $Vault
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }
 
@@ -39,7 +39,7 @@ function Disconnect-LastPass {
         [String]$Vault
     )
     $Arguments = [System.Collections.Generic.List[String]]@('logout', '--force')
-    $VaultParams = Get-VaultParams -VaultName $Vault
+    $VaultParams = Get-VaultParams -Vault $Vault
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }
 
@@ -78,7 +78,7 @@ function Unregister-LastPassVault {
 function Sync-LastPassVault {
     [CmdletBinding()]
     param ([String]$Vault)
-    $VaultParams = Get-VaultParams -VaultName $Vault
+    $VaultParams = Get-VaultParams -Vault $Vault
     Invoke-lpass -Arguments 'sync' -VaultParams $VaultParams
 }
 Function Get-VaultParams {

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -102,7 +102,6 @@ $VaultNameLPArgcompleter = {
     return Get-SecretVault -Name "*$wordToComplete*" | Where-Object ModuleName -eq $ModuleName | Select-Object -ExpandProperty Name
 }
 
-
 Register-ArgumentCompleter -CommandName 'Register-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameArgcompleter
 Register-ArgumentCompleter -CommandName 'Unregister-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultNameLPArgcompleter
 #endregion

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -65,13 +65,12 @@ function Register-LastPassVault {
 function Unregister-LastPassVault {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
         [String]$VaultName
     )
-    $Params = @{VaultName = if ('' -ne $VaultName) { $VaultName } else { $ModuleName } }
+    $Params = @{Name = if ('' -ne $VaultName) { $VaultName } else { $ModuleName } }
     if ($VerbosePreference -eq 'Continue') {$Params.Add('Verbose',$true)}
     
-    $Vault = Get-SecretVault -Name $params.VaultName -ErrorAction Stop
+    $Vault = Get-SecretVault -Name $params.Name -ErrorAction Stop
     if ($Vault.ModuleName -ne $ModuleName) { Throw $ErrorMessages.Unregister_NotLpass_1 -f $Vault.ModuleName}
     Unregister-SecretVault @Params 
 }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -83,7 +83,8 @@ function Sync-LastPassVault {
     $VaultParams = Get-VaultParams -Vault $Vault
     Invoke-lpass -Arguments 'sync' -VaultParams $VaultParams
 }
-Function Get-VaultParams {
+
+function Get-VaultParams {
     Param($Vault)
     if ([String]::IsNullOrEmpty($Vault)) { 
         $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -75,6 +75,12 @@ function Unregister-LastPassVault {
     Unregister-SecretVault @Params 
 }
 
+function Sync-LastPassVault {
+    [CmdletBinding()]
+    param ([String]$VaultName)
+    $VaultParams = Get-VaultParams -VaultName $VaultName
+    Invoke-lpass -Arguments 'Sync' -VaultParams $VaultParams
+}
 Function Get-VaultParams {
     Param($VaultName)
     if ([String]::IsNullOrEmpty($VaultName)) { 

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -30,20 +30,19 @@ function Disconnect-LastPass {
 function Register-LastPassVault {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
         [String]$VaultName,
         [String]$Command,
         [String]$Path
     )
- 
+
     $Params = @{
         ModuleName      = 'SecretManagement.LastPass'
-        Name            = $VaultName
+        Name            = if ('' -ne $VaultName) {$VaultName} else {$ModuleName}
         VaultParameters = @{}
     }
-
     if ('' -ne $Command) { $Params.VaultParameters.Add('lpassCommand', $Command) }
     if ('' -ne $Path) { $Params.VaultParameters.Add('lpassPath', $Path) }
+    if ($VerbosePreference -eq 'Continue') {$Params.add('Verbose',$true)}
 
     Register-SecretVault @Params
 }
@@ -53,7 +52,12 @@ function Unregister-LastPassVault {
         [Parameter(Mandatory = $true)]
         [String]$VaultName
     )
-    Unregister-SecretVault -Name $VaultName 
+    $Params = @{Name = if ('' -ne $VaultName) { $VaultName } else { $ModuleName }}
+    if ($VerbosePreference -eq 'Continue') {$Params.Add('Verbose',$true)}
+    
+    $Vault = Get-SecretVault -Name $params.VaultName -ErrorAction Stop
+    if ($Vault.ModuleName -ne $ModuleName) {Throw "The specified vault is not a $ModuleName vault (VaultType: $($Vault.ModuleName)"}
+    Unregister-SecretVault @Params 
 }
 
 Function Get-VaultParams {

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -48,6 +48,7 @@ function Register-LastPassVault {
     param (
         [String]$Vault,
         [switch]$wsl,
+        [Switch]$Detailed,
         [String]$Path
     )
 
@@ -58,6 +59,7 @@ function Register-LastPassVault {
     }
     if ($wsl -eq $true) { $Params.VaultParameters.Add('wsl', $true) }
     if ($Path -ne '') { $Params.VaultParameters.Add('lpassPath', $Path) }
+    if ($Detailed -eq $true) { $Params.VaultParameters.Add('outputType','Detailed') }
     if ($VerbosePreference -eq 'Continue') {$Params.add('Verbose',$true)}
 
     Register-SecretVault @Params

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -79,7 +79,7 @@ function Sync-LastPassVault {
     [CmdletBinding()]
     param ([String]$Vault)
     $VaultParams = Get-VaultParams -VaultName $Vault
-    Invoke-lpass -Arguments 'Sync','--now' -VaultParams $VaultParams
+    Invoke-lpass -Arguments 'sync' -VaultParams $VaultParams
 }
 Function Get-VaultParams {
     Param($Vault)

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -201,6 +201,8 @@ function Get-VaultParams {
         $DefaultVault = Get-SecretVault -Name $ModuleName -ErrorAction SilentlyContinue
         if ($null -ne $DefaultVault) { return $DefaultVault.VaultParameters }
 
+        # If no vault name provided and SecretManagement.LastPass is not a valid vault
+        # We pick the vault automatically if there's only one or throw an error.
         $AllVaults = Get-SecretVault | Where-Object ModuleName -eq $ModuleName
         switch ($AllVaults.count) {
             0 { Throw $ErrorMessages.GetVaultParams0; break }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -22,7 +22,7 @@ function Disconnect-LastPass {
     param (
         [String]$VaultName
     )
-    $Arguments = [System.Collections.Generic.List[String]]@('logout')
+    $Arguments = [System.Collections.Generic.List[String]]@('logout', '--force')
     $VaultParams = Get-VaultParams -VaultName $VaultName
     Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -47,7 +47,7 @@ function Register-LastPassVault {
     [CmdletBinding()]
     param (
         [String]$Vault,
-        [switch]$wsl,
+        [switch]$Wsl,
         [Switch]$Detailed,
         [String]$Path
     )
@@ -57,7 +57,7 @@ function Register-LastPassVault {
         Name            = if ('' -ne $Vault) {$Vault} else {$ModuleName}
         VaultParameters = @{}
     }
-    if ($wsl -eq $true) { $Params.VaultParameters.Add('wsl', $true) }
+    if ($Wsl -eq $true) { $Params.VaultParameters.Add('wsl', $true) }
     if ($Path -ne '') { $Params.VaultParameters.Add('lpassPath', $Path) }
     if ($Detailed -eq $true) { $Params.VaultParameters.Add('outputType','Detailed') }
     if ($VerbosePreference -eq 'Continue') {$Params.add('Verbose',$true)}

--- a/test/Extension.Tests.ps1
+++ b/test/Extension.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'SecretManagement.LastPass tests' {
     It 'Can store a string secret which is treated like a securestring' {
         $secretText = 'This is my string secret'
         Set-Secret -Name $secretName -Vault $VaultName -Secret $secretText
+        Sync-LastPassVault -Vault $VaultName
 
         $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
         $secretInfo.Name | Should -BeLike "$secretName (id:*)"
@@ -32,6 +33,7 @@ Describe 'SecretManagement.LastPass tests' {
     It 'Can store a secure string secret' {
         $secretText = 'This is my securestring secret'
         Set-Secret -Name $secretName -Vault $VaultName -Secret ($secretText | ConvertTo-SecureString -AsPlainText -Force)
+        Sync-LastPassVault -Vault $VaultName
 
         $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
         $secretInfo.Name | Should -BeLike "$secretName (id:*)"
@@ -49,6 +51,7 @@ Describe 'SecretManagement.LastPass tests' {
         $secretText = 'This is my pscredential secret'
         $secret = [PSCredential]::new('myUser', ($secretText | ConvertTo-SecureString -AsPlainText -Force))
         Set-Secret -Name $secretName -Vault $VaultName -Secret $secret
+        Sync-LastPassVault -Vault $VaultName
 
         $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
         $secretInfo.Name | Should -BeLike "$secretName (id:*)"
@@ -70,6 +73,7 @@ Describe 'SecretManagement.LastPass tests' {
         $secretText = 'This is my byte array secret'
         $bytes = [System.Text.Encoding]::UTF8.GetBytes($secretText)
         Set-Secret -Name $secretName -Vault $VaultName -Secret $bytes
+        Sync-LastPassVault -Vault $VaultName
 
         $secretInfo = Get-SecretInfo -Name $secretName
         $secretInfo.Name | Should -BeExactly $secretName
@@ -100,6 +104,8 @@ Describe 'SecretManagement.LastPass tests' {
         }
 
         Set-Secret -Name $secretName -Vault $VaultName -Secret $hashtable
+        Sync-LastPassVault -Vault $VaultName
+
         $secretInfo = Get-SecretInfo -Name $secretName
         $secretInfo.Name | Should -BeExactly $secretName
         $secretInfo.Type | Should -BeExactly 'Hashtable'

--- a/test/Extension.Tests.ps1
+++ b/test/Extension.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'SecretManagement.LastPass tests' {
     BeforeAll {
-        & $PSScriptRoot/reload.ps1
+        . $PSScriptRoot/reload.ps1
         $VaultName = 'LastPass.Tests'
     }
 
@@ -31,7 +31,7 @@ Describe 'SecretManagement.LastPass tests' {
 
     It 'Can store a secure string secret' {
         $secretText = 'This is my securestring secret'
-        Set-Secret -Name $secretName -Vault $VaultName -Secret ($secretText | ConvertTo-SecureString -AsPlainText)
+        Set-Secret -Name $secretName -Vault $VaultName -Secret ($secretText | ConvertTo-SecureString -AsPlainText -Force)
 
         $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
         $secretInfo.Name | Should -BeLike "$secretName (id:*)"
@@ -47,7 +47,7 @@ Describe 'SecretManagement.LastPass tests' {
 
     It 'Can store a PSCredential secret' {
         $secretText = 'This is my pscredential secret'
-        $secret = [PSCredential]::new('myUser', ($secretText | ConvertTo-SecureString -AsPlainText))
+        $secret = [PSCredential]::new('myUser', ($secretText | ConvertTo-SecureString -AsPlainText -Force))
         Set-Secret -Name $secretName -Vault $VaultName -Secret $secret
 
         $secretInfo = Get-SecretInfo -Name $secretName -Vault $VaultName
@@ -86,8 +86,8 @@ Describe 'SecretManagement.LastPass tests' {
     # Skipping because I don't think this extension supports arbitrary hashtables.
     It 'Can store hashtable secret' -Skip {
         $secretText = 'This is my hashtable secret'
-        $cred = [pscredential]::new('myUser', ($secretText | convertto-securestring -asplaintext))
-        $securestring = $secretText | convertto-securestring -asplaintext
+        $cred = [pscredential]::new('myUser', ($secretText | convertto-securestring -AsPlainText -Force))
+        $securestring = $secretText | convertto-securestring -AsPlainText -Force
         $hashtable = @{
             a = 1
             b = $cred

--- a/test/reload.ps1
+++ b/test/reload.ps1
@@ -1,3 +1,10 @@
+#Legacy Windows 5.1
+if ($null -eq $IsWindows) {
+    Function ConvertFrom-SecureString([parameter(ValueFromPipeline)]$InputObject, [Switch]$AsPlainText) {
+        return [pscredential]::new('MyUser', $InputObject).GetNetworkCredential().Password 
+    }
+}
+
 if (Get-SecretVault 'LastPass.Tests' -ErrorAction Ignore) {
     Unregister-SecretVault 'LastPass.Tests'
 }
@@ -10,6 +17,9 @@ foreach ($module in $modules) {
     }
 }
 
-Register-SecretVault (Join-Path $PSScriptRoot '..' 'SecretManagement.LastPass.psd1') -Name 'LastPass.Tests'
+$ModulePath = Join-Path "$PSScriptRoot/.."  'SecretManagement.LastPass.psd1'
 
-Import-Module (Join-Path $PSScriptRoot '..' 'SecretManagement.LastPass.psd1') -Force
+if ($IsWindows -in @($true, $null)) {$Params = @{VaultParameters = @{wsl = $true}}}
+Register-SecretVault $ModulePath -Name 'LastPass.Tests' @Params
+Import-Module $ModulePath -Force
+


### PR DESCRIPTION
Connect / Disconnect (manage connecting to lpass)
By exposing the Connect function, the user do not have to know anything about the cli syntax at all...

Register / Unregister
Register-LastPassVault is more complete than Register-SecretVault since we can have specific parameters for command / path without having to go check the doc.

eg:

```
Register-LassPassVault -VaultName MyVault -Command wsl
```
instead of

```
  $Params = @{
        ModuleName = 'SecretManagement.LastPass'
        Name = 'MyVault'
        VaultParameters = @{lpassCommand = wsl}
    }

Register-SecretVault @Params
```
This open the door to adding more CLI element into the module later on.