### PR TITLE
Bugfix/get secret logged out

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -2,9 +2,6 @@
 # Licensed under the MIT License.
 using namespace Microsoft.PowerShell.SecretManagement
 
-# We suppress (redirect) the CLI native error stream by default
-$PSDefaultParameterValues["Invoke-lpass:ErrorActionPreference"] = "SilentlyContinue"
-
 #region constants
 
 # The capture groups are:
@@ -140,7 +137,7 @@ function Get-Secret
         $Name = $Matches[1]
     }
 
-    $res = Invoke-lpass 'show', '--name', $Name, '--all' -ErrorAction Continue
+    $res = Invoke-lpass 'show', '--name', $Name, '--all' -ErrorAction SilentlyContinue
 
     # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
     if ($null -eq $res -or $res.ToString() -eq $lpassMessage.AccountNotFound) {
@@ -245,7 +242,7 @@ function Set-Secret
         }
     } 
     
-    $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction Continue
+    $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
 
     # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
     $SecretExists = switch -Wildcard ($res) {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -273,7 +273,7 @@ function Set-Secret
         }
     }
 
-    if ($Secret -is [System.Collections.Specialized.OrderedDictionary] -or $Secret -is [hashtable]) {
+    if ($Secret -is [System.Collections.IDictionary]) {
         if ($Secret.Keys.count -eq 1 -and $null -ne $Secret.Notes) {
             $Secret.URL = 'http://sn'
         }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -115,9 +115,9 @@ function Invoke-lpass {
                 # If we get the message stating we might be logged out, we reissue the command without redirect (for Prompt)
                 if ($result -is [System.Management.Automation.ErrorRecord] -and [String]$result -like $lpassMessage.LoggedOut) {
                     $result2 = Invoke-lpassInternal @Params
-                    # If $null, something will have been printed in the console (because we disabled the redirect)
+                    # If $result2 -eq $null, something will have been printed in the console (because we disabled the redirect)
                     # We therefore want to keep the original $result "Logged out" so it is thrown later on
-                    # If not $null, we want to evaluate $result2
+                    # If not $null, we want to evaluate $result2 instead and discard $result
                     if ($null -ne $result2) {$result = $result2}
                 }
             }

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 using namespace Microsoft.PowerShell.SecretManagement
 
+# We suppress (redirect) the CLI native error stream by default
+$PSDefaultParameterValues["Invoke-lpass:ErrorActionPreference"] = "SilentlyContinue"
+
 #region constants
 
 # The capture groups are:
@@ -137,7 +140,7 @@ function Get-Secret
         $Name = $Matches[1]
     }
 
-    $res = Invoke-lpass 'show', '--name', $Name, '--all' -ErrorAction SilentlyContinue
+    $res = Invoke-lpass 'show', '--name', $Name, '--all' -ErrorAction Continue
 
     # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
     if ($null -eq $res -or $res.ToString() -eq $lpassMessage.AccountNotFound) {
@@ -242,7 +245,7 @@ function Set-Secret
         }
     } 
     
-    $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction SilentlyContinue
+    $res = Invoke-lpass 'show', '--sync=now', '--name', $Name -ErrorAction Continue
 
     # We use ToString() here to turn the ErrorRecord into a string if we got an ErrorRecord
     $SecretExists = switch -Wildcard ($res) {

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -114,7 +114,7 @@ function Invoke-lpass {
                 $result = Invoke-lpassInternal @Params 2>&1
                 # If we get the message stating we might be logged out, we reissue the command without redirect (for Prompt)
                 if ($result -is [System.Management.Automation.ErrorRecord] -and [String]$result -like $lpassMessage.LoggedOut) {
-                    $result2 = Invoke-lpassInternal @Params 2>&1
+                    $result2 = Invoke-lpassInternal @Params
                     # If $null, something will have been printed in the console (because we disabled the redirect)
                     # We therefore want to keep the original $result "Logged out" so it is thrown later on
                     # If not $null, we want to evaluate $result2

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -130,7 +130,7 @@ function Invoke-lpass {
                 # We want the prompt always, so no redirect
                 $result = Invoke-lpassInternal @Params
             }
-            'show' {
+            {$_ -in 'show','ls','rm'} {
                 # We might want the prompt, but are not sure yet.
                 $result = Invoke-lpassInternal @Params 2>&1
                 # If we get the message stating we might be logged out, we reissue the command without redirect (for Prompt)
@@ -139,7 +139,7 @@ function Invoke-lpass {
                     # If $result2 -eq $null, something will have been printed in the console (because we disabled the redirect)
                     # We therefore want to keep the original $result "Logged out" so it is thrown later on
                     # If not $null, we want to evaluate $result2 instead and discard $result
-                    if ($null -ne $result2) {$result = $result2}
+                    if ($null -ne $result2 -or $Arguments[0] -eq 'rm') { $result = $result2 }
                 }
             }
             Default {

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -66,7 +66,7 @@ function Connect-LastPass {
     }
     $Arguments.Add($User)
     $VaultParams = Get-VaultParams -Vault $Vault
-    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams -NoErrStreamRedirect
 }
 
 <#

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -7,7 +7,7 @@ $ModuleName = 'SecretManagement.LastPass'
 # The last segement (underscore + number (eg: _1)) is to view how many format args are expected.
 $ErrorMessages = @{
     GetVaultParams0                 = "At least 1 vault implementing $ModuleName must be registered."
-    GetVaultParamsMany_1            = "`$Vault argument must be provided when multiple vault implementing $ModuleName exists: {0}"
+    GetVaultParamsMany_1            = "Multiple vault implementing $ModuleName exists: {0}. You must specify a vault name."
     Unregister_NotLpass_1           = "The specified vault is not a $ModuleName vault (VaultType: {0}"
 }
 <#
@@ -124,7 +124,7 @@ Register a vault called MyVault that will be called through wsl and work with th
 function Register-LastPassVault {
     [CmdletBinding()]
     param (
-        [String]$Vault,
+        [String]$Name,
         [switch]$Wsl,
         [Switch]$Detailed,
         [String]$Path
@@ -132,7 +132,7 @@ function Register-LastPassVault {
 
     $Params = @{
         ModuleName      = 'SecretManagement.LastPass'
-        Name            = if ('' -ne $Vault) {$Vault} else {$ModuleName}
+        Name            = if ('' -ne $Name) {$Name} else {$ModuleName}
         Verbose         = $VerbosePreference -eq 'Continue'
         VaultParameters = @{
             wsl         = $Wsl.IsPresent
@@ -163,10 +163,10 @@ Unregister the vault 'MyVault'.
 function Unregister-LastPassVault {
     [CmdletBinding()]
     param (
-        [String]$Vault
+        [String]$Name
     )
     $Params = @{
-        Name = if ('' -ne $Vault) { $Vault } else { $ModuleName }
+        Name = if ('' -ne $Name) { $Name } else { $ModuleName }
         Verbose = $VerbosePreference -eq 'Continue'
     }
     
@@ -226,6 +226,6 @@ $VaultLPArgcompleter = {
     return Get-SecretVault -Name "*$wordToComplete*" | Where-Object ModuleName -eq $ModuleName | Select-Object -ExpandProperty Name
 }
 
-Register-ArgumentCompleter -CommandName 'Register-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultArgcompleter
-Register-ArgumentCompleter -CommandName 'Unregister-LastPassVault' -ParameterName 'VaultName' -ScriptBlock $VaultLPArgcompleter
+Register-ArgumentCompleter -CommandName 'Register-LastPassVault' -ParameterName 'Name' -ScriptBlock $VaultArgcompleter
+Register-ArgumentCompleter -CommandName 'Unregister-LastPassVault' -ParameterName 'Name' -ScriptBlock $VaultLPArgcompleter
 #endregion

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 using namespace Microsoft.PowerShell.SecretManagement
 
+# We suppress (redirect) the CLI native error stream by default
+$PSDefaultParameterValues["Invoke-lpass:ErrorActionPreference"] = "SilentlyContinue"
+
 $ModuleName = 'SecretManagement.LastPass'
 
 # The last segement (underscore + number (eg: _1)) is to view how many format args are expected.

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -66,7 +66,7 @@ function Connect-LastPass {
     }
     $Arguments.Add($User)
     $VaultParams = Get-VaultParams -Vault $Vault
-    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams -NoErrStreamRedirect
+    Invoke-lpass -Arguments $Arguments -VaultParams $VaultParams
 }
 
 <#

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -2,9 +2,6 @@
 # Licensed under the MIT License.
 using namespace Microsoft.PowerShell.SecretManagement
 
-# We suppress (redirect) the CLI native error stream by default
-$PSDefaultParameterValues["Invoke-lpass:ErrorActionPreference"] = "SilentlyContinue"
-
 $ModuleName = 'SecretManagement.LastPass'
 
 # The last segement (underscore + number (eg: _1)) is to view how many format args are expected.

--- a/test/reload.ps1
+++ b/test/reload.ps1
@@ -19,7 +19,11 @@ foreach ($module in $modules) {
 
 $ModulePath = Join-Path "$PSScriptRoot/.."  'SecretManagement.LastPass.psd1'
 
-if ($IsWindows -in @($true, $null)) {$Params = @{VaultParameters = @{wsl = $true}}}
+$Params = if ($IsLinux -or $IsMacOS) {
+    @{}
+} else {
+    @{ VaultParameters = @{ wsl = $true }}
+}
+
 Register-SecretVault $ModulePath -Name 'LastPass.Tests' @Params
 Import-Module $ModulePath -Force
-


### PR DESCRIPTION
It looks like I inverted the IgnoreError part in the main branch when I did the rework on Invoke-Lpass.
It caused the prompt not to show (again)

While working on a solution, I entered other issues with the stream redirection.
During debug, it seemed that calling Invoke-Lpass with the redirect reacted differently than applying it on the lpass CLI result itself.

Lpass cli result returned $null in some occasion where doing it on Invoke-Lpass worked consistently no matter what the call.


Therefore, I created a function where I wrapped the call logic and used that within Invoke-lpass.

Not only the issue is fixed but the whole thing is improved. 

`-ErrorAction SilentlyContinue` is not used anymore.
I found that a bit confusing since in all cases, we generated errors (CLI or otherwise) from the function. 
Instead, this is managed depending on the command with more granularity. 

- login
Always show prompt and thus always show native error (if any)

- show
**Before**
- command not redirected (for prompt if needed)
- Native error shown in console
- Secret was not found error shown even though it should be a logged out error (since we didn't capture the CLI output and left it through) 

**Now**
- Command is redirected
- We check for the logged out message
- If we get it, we do a second call without redirection and we'll get one of the following results:
1: Prompt (because the session was disconnected)
2: native error + logged out message (because we are truly logged out) 

If you are connected, you won't get the native error showing anymore either. 

