### PR TITLE
Use Ordered dictionary to preserve order + Removal of case sensitivity for Get-SecretInfo filter

### DIFF
--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -317,7 +317,7 @@ function Get-SecretInfo
     }
 
     $Filter = "*$Filter"
-    $pattern = [WildcardPattern]::new($Filter)
+    $pattern = [WildcardPattern]::new($Filter,[System.Management.Automation.WildcardOptions]::IgnoreCase)
     Invoke-lpass 'ls','-l' |
         Where-Object { 
             $IsMatch = $_ -match $lsLongOutput 

--- a/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
+++ b/SecretManagement.LastPass.Extension/SecretManagement.LastPass.Extension.psm1
@@ -220,7 +220,7 @@ function Set-Secret
         }
     }
 
-    if ($Secret -is [hashtable]){
+    if ($Secret -is [System.Collections.Specialized.OrderedDictionary] -or $Secret -is [hashtable]) {
         if ($Secret.Keys.count -eq 1 -and $null -ne $Secret.Notes) {
             $Secret.URL = 'http://sn'
         }
@@ -391,15 +391,11 @@ function Get-ComplexSecret {
     $DupeNote = ($Fields.Contains('Notes') -and ![String]::IsNullOrEmpty($Note))
     if ($Dupes.Count -gt 0 -or $DupeNote) {
         Write-Verbose 'Creating case-sensitve hashtable'
-        $Output = [hashtable]::new([System.StringComparer]::InvariantCulture)
+        $Output = [System.Collections.Specialized.OrderedDictionary]::new([System.StringComparer]::CurrentCultureIgnoreCase)
     } else {
-        $Output = @{}
+        $Output = [Ordered]@{}
     }
     
-    if (![String]::IsNullOrEmpty($Note)) { 
-        $Output.Notes = $Note
-    }
-
     Foreach ($f in $Fields) {
         try {
             $Output.Add($f.key, $f.value) 
@@ -411,5 +407,10 @@ function Get-ComplexSecret {
     if ($null -ne $Output.NoteType -and $DefaultNoteTypeMap.ContainsKey($Output.NoteType)) {
         $Output.NoteType = $DefaultNoteTypeMap.Item($Output.NoteType)
     }
+
+    if (![String]::IsNullOrEmpty($Note)) { 
+        $Output.Notes = $Note
+    }
+
     return $Output
 }


### PR DESCRIPTION
Changes: 

Secrets now use Ordered dictionary so order is preserved.
Secrets fields are displayed in the same order than LastPass send them instead of alphabetically

This mean instead of : 
```
Notes
Password
Url
Username, 
```

you get

```
Username
Password
Url 
Notes
```

Also, Get-SecretInfo is now case-insensitive. 
I think this make more sense, just like when you search from the web UI, to search without considering the case. 

