### PR TITLE
Show-LastPassConsoleGridView + Get-VaultParams changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ If set, the secret GridView will be automatically reloaded after a secret is sho
 If set, Secret will be returned as is without formatting.
 
 ###### Notes
-Requires Powershell 6.2 or newer and Microsoft.Powershell.ConsoleGuiTools module to use.
+This cmdlet can make use of the improved Out-ConsoleGridView cmdlet if using Powershell 6.2 or newer and  Microsoft.PowerShell.ConsoleGuiTools is installed.
+Otherwise, Out-GridView will be used.
 
 ## Extension Limitations
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Forces a synchronization of the local cache with the LastPass servers, and does 
 ##### Vault
 Name of the vault
 
-### Show-LastPassConsoleGridView
+### Show-LastPassGridView
 Show LastPass GridView secrets then show the selected secret.
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ Forces a synchronization of the local cache with the LastPass servers, and does 
 ##### Vault
 Name of the vault
 
+### Show-LastPassConsoleGridView
+Show LastPass GridView secrets then show the selected secret.
+#### Parameters
+
+##### Vault
+Name of the vault used for the lookup
+
+###### [Switch]KeepOpen
+If set, the secret GridView will be automatically reloaded after a secret is shown
+
+##### [Switch]PassThru
+If set, Secret will be returned as is without formatting.
+
+###### Notes
+Requires Powershell 6.2 or newer and Microsoft.Powershell.ConsoleGuiTools module to use.
+
+
 ## Extension Limitations
 
 Some limitations exist on this module, inherent to the CLI they are based on. 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Name of the vault used for the lookup
 ###### [Switch]KeepOpen
 If set, the secret GridView will be automatically reloaded after a secret is shown
 
-##### [Switch]PassThru
-If set, Secret will be returned as is without formatting.
+##### [Switch]Formatted
+If set, Secret will be returned with the title and in a Format-Table -Wrap to show multiline note properly.
 
 ###### Notes
 This cmdlet can make use of the improved Out-ConsoleGridView cmdlet if using Powershell 6.2 or newer and  Microsoft.PowerShell.ConsoleGuiTools is installed.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ If set, Secret will be returned as is without formatting.
 ###### Notes
 Requires Powershell 6.2 or newer and Microsoft.Powershell.ConsoleGuiTools module to use.
 
-
 ## Extension Limitations
 
 Some limitations exist on this module, inherent to the CLI they are based on. 

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -50,7 +50,7 @@
     NestedModules     = './SecretManagement.LastPass.Extension'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault','Sync-LastPassVault')
+    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault','Sync-LastPassVault','Show-LastPassConsoleGridView')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/SecretManagement.LastPass.psd1
+++ b/SecretManagement.LastPass.psd1
@@ -50,7 +50,7 @@
     NestedModules     = './SecretManagement.LastPass.Extension'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault','Sync-LastPassVault','Show-LastPassConsoleGridView')
+    FunctionsToExport = @('Connect-LastPass', 'Disconnect-Lastpass', 'Register-LastPassVault', 'Unregister-LastPassVault','Sync-LastPassVault','Show-LastPassGridView')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -262,6 +262,10 @@ Function Show-LastPassConsoleGridView {
         Write-Debug "Microsoft.Powershell.ConsoleGuiTools could not be loaded.`n$($_ | Out-String)"
     }
 
+    if (!$UseConsoleGridView -and (Get-Command Out-GridView -ErrorAction Stop)){
+        throw "Can't find a grid view cmdlet. Try installing the 'Microsoft.PowerShell.ConsoleGuiTools' module and try again."
+    }
+
     $Vault = (Get-SelectedVault -Vault $Vault).Name
     $LastPassSecretInfoCache = Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*"
 

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -247,9 +247,7 @@ function Show-LastPassConsoleGridView {
     Param(
         [String]$Vault,
         [String]$Filter,
-        [Parameter(ParameterSetName = 'KeepOpen')]
         [Switch]$KeepOpen,
-        [Parameter(ParameterSetName = 'Formatted')]
         [Switch]$Formatted
     )
     

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -281,6 +281,15 @@ function Show-LastPassConsoleGridView {
 
             # Intended for view, not for assignement. Add secret title and expand multiline notes in the console.
             Write-host $Result.Name -ForegroundColor Cyan
+            
+            # If outputType is Default, we won't get a hashtable for simple secret but might get a PSCredential
+            if ($Secret -is [pscredential]) {
+                $Secret = @{
+                 UserName = $Secret.UserName
+                 Password = $Secret.GetNetworkCredential().Password
+                }
+            }
+
             $Secret | Format-Table -Wrap
             
             if ($KeepOpen) { 

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -260,10 +260,9 @@ Function Show-LastPassConsoleGridView {
     }
     catch {
         Write-Debug "Microsoft.Powershell.ConsoleGuiTools could not be loaded.`n$($_ | Out-String)"
-    }
-    
-    if (!$UseConsoleGridView -and $null -eq (Get-Command Out-GridView -ErrorAction SilentlyContinue)) {
-        throw "Can't find a grid view cmdlet. Try installing the 'Microsoft.PowerShell.ConsoleGuiTools' module and try again."
+        if ($null -eq (Get-Command Out-GridView -ErrorAction SilentlyContinue)) {
+            throw "Can't find a grid view cmdlet. Try installing the 'Microsoft.PowerShell.ConsoleGuiTools' module and try again."
+        }
     }
 
     $Vault = (Get-SelectedVault -Vault $Vault).Name

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -236,13 +236,13 @@ If set, the secrets GridView will be automatically reloaded after a secret is sh
 If set, Secret will be returned with the title and in a Format-Table -Wrap to show multiline note properly.
 
 .EXAMPLE
-Show-LastPassConsoleGridView -Vault MyVault -KeepOpen 
+Show-LastPassGridView -Vault MyVault -KeepOpen 
 
 .NOTES
 This cmdlet can make use of the improved Out-ConsoleGridView cmdlet if using Powershell 6.2 or newer and  Microsoft.PowerShell.ConsoleGuiTools is installed.
 Otherwise, Out-GridView will be used.
 #>
-function Show-LastPassConsoleGridView {
+function Show-LastPassGridView {
     [CmdletBinding(DefaultParameterSetName='Default')]
     Param(
         [String]$Vault,

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -261,8 +261,8 @@ Function Show-LastPassConsoleGridView {
     catch {
         Write-Debug "Microsoft.Powershell.ConsoleGuiTools could not be loaded.`n$($_ | Out-String)"
     }
-
-    if (!$UseConsoleGridView -and (Get-Command Out-GridView -ErrorAction Stop)){
+    
+    if (!$UseConsoleGridView -and $null -eq (Get-Command Out-GridView -ErrorAction SilentlyContinue)) {
         throw "Can't find a grid view cmdlet. Try installing the 'Microsoft.PowerShell.ConsoleGuiTools' module and try again."
     }
 

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -242,7 +242,7 @@ Show-LastPassConsoleGridView -Vault MyVault -KeepOpen
 This cmdlet can make use of the improved Out-ConsoleGridView cmdlet if using Powershell 6.2 or newer and  Microsoft.PowerShell.ConsoleGuiTools is installed.
 Otherwise, Out-GridView will be used.
 #>
-Function Show-LastPassConsoleGridView {
+function Show-LastPassConsoleGridView {
     [CmdletBinding(DefaultParameterSetName='Default')]
     Param(
         [String]$Vault,

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -246,7 +246,7 @@ function Show-LastPassConsoleGridView {
     [CmdletBinding(DefaultParameterSetName='Default')]
     Param(
         [String]$Vault,
-        [String]$Filter = '*',
+        [String]$Filter,
         [Parameter(ParameterSetName = 'KeepOpen')]
         [Switch]$KeepOpen,
         [Parameter(ParameterSetName = 'PassThru')]


### PR DESCRIPTION
A "candy" cmdlet that integrate Microsoft.PowerShell.ConsoleGuiTools. 
You might know of this module ? If not, see [this](https://devblogs.microsoft.com/powershell/introducing-consoleguitools-preview/) 😉 

I think that will be probably one of my favorite way to go about consulting the vault from now on. 
I didn't want to add the module as a required dependency so instead, an error is thrown if it is used without the module installed.
A warning is also thrown if you are using 5.1  or anything below 6.2 for that matter.

All that would be missing is a cute Gif with it in action (using a test vault). 
You can create a one line PS script and use it whenever with the KeepOpen parameter and / or use it interactively to select a secret and return it unformatted with PassThru.

I think this tie up everything nicely as you now have a one-liner interface at your fingertips.

Edit: Oh yeah, I changed `Get-VaultParams` for `Get-SelectedVault` which does essentially the same thing but return the vault info instead of the parameter since I wanted the error management from that cmdlet into the new cmdlet but I also needed to get back the name of the vault and not its parameters.

