### PR TITLE
[High]Hotfix - Get-SelectedVault broken

### DIFF
--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -211,8 +211,8 @@ function Get-SelectedVault {
         }
     }
 
-    $VaultParams = (Get-SecretVault -Name $Vault -ErrorAction Stop).VaultParameters
-    return $VaultParams
+    $SelectedVault = (Get-SecretVault -Name $Vault -ErrorAction Stop)
+    return $SelectedVault
 
 }
 


### PR DESCRIPTION
Everything that use the return of this cmdled (old name: `Get-VaultParams` changed from getting the vault parameters to the vault info. Everything was changed but the actual return type, which mean currently, everything that use `Get-SelectedVault` (new name) have `$null` value. 

This is kind of a Need a hotfix published type of issue. 😞 