### PR TITLE
Cleaner Show-LastPassSecret Interface

### DIFF
--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -265,9 +265,12 @@ function Show-LastPassGridView {
 
     $Vault = (Get-SelectedVault -Vault $Vault).Name
     $LastPassSecretInfoCache = (Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*") | ForEach-Object {
-        $MyMatches = [regex]::Matches($_.Name, '(?<Name>.*)\(id: (?<Id>.*)\)')
+        $MyMatches = [regex]::Matches($_.Name, '(?<Group>.*?)/(?<Name>.*)\(id: (?<Id>.*)\)')
+        $Group = $MyMatches[0].Groups['Group'].Value.replace('(none)','')
         [PSCustomObject]@{
-            Name = $MyMatches[0].Groups['Name'].Value
+            Name   = $MyMatches[0].Groups['Name'].Value
+            # Folder can be quite long, but also very short (eg: none) so Name should be the most visible item
+            Folder = $Group
             Id   = $MyMatches[0].Groups['Id'].Value
         }
     }
@@ -280,7 +283,7 @@ function Show-LastPassGridView {
         }
         
         if ($null -eq $Result) { break }
-            $Secret = Microsoft.Powershell.SecretManagement\Get-Secret -Vault $Vault -Name "$($Result.Name) (id: $($Result.Id))" -AsPlainText
+            $Secret = Microsoft.Powershell.SecretManagement\Get-Secret -Vault $Vault -Name $Result.Id -AsPlainText
             
             # By default, return the secret as is, everything will be fine
             if (!$Formatted) {return $Secret}

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -264,7 +264,7 @@ function Show-LastPassGridView {
     }
 
     $Vault = (Get-SelectedVault -Vault $Vault).Name
-    $LastPassSecretInfoCache = (Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*") | ForEach-Object {
+    $LastPassSecretInfoCache = Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*" | ForEach-Object {
         $MyMatches = [regex]::Matches($_.Name, '(?<Group>.*?)/(?<Name>.*)\(id: (?<Id>.*)\)')
         $Group = $MyMatches[0].Groups['Group'].Value.replace('(none)','')
         [PSCustomObject]@{

--- a/SecretManagement.LastPass.psm1
+++ b/SecretManagement.LastPass.psm1
@@ -264,7 +264,13 @@ function Show-LastPassGridView {
     }
 
     $Vault = (Get-SelectedVault -Vault $Vault).Name
-    $LastPassSecretInfoCache = Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*"
+    $LastPassSecretInfoCache = (Microsoft.Powershell.SecretManagement\Get-SecretInfo -Vault $Vault -Name "$Filter*") | ForEach-Object {
+        $MyMatches = [regex]::Matches($_.Name, '(?<Name>.*)\(id: (?<Id>.*)\)')
+        [PSCustomObject]@{
+            Name = $MyMatches[0].Groups['Name'].Value
+            Id   = $MyMatches[0].Groups['Id'].Value
+        }
+    }
 
     do {
         if ($UseConsoleGridView) {
@@ -274,7 +280,7 @@ function Show-LastPassGridView {
         }
         
         if ($null -eq $Result) { break }
-            $Secret = Microsoft.Powershell.SecretManagement\Get-Secret -Vault $Vault -Name $Result.Name -AsPlainText
+            $Secret = Microsoft.Powershell.SecretManagement\Get-Secret -Vault $Vault -Name "$($Result.Name) (id: $($Result.Id))" -AsPlainText
             
             # By default, return the secret as is, everything will be fine
             if (!$Formatted) {return $Secret}


### PR DESCRIPTION
I don't think we need to output Type / vaultname here. 
Vault name is written at the top already.

Then, we can separate Name and ID.
We need the ID because of possible clash if we rely just on name but no need to put it all in the user face.


Before
![image](https://user-images.githubusercontent.com/1980296/99895471-66e49c80-2c56-11eb-9be4-7121a4317cb4.png)


After
![image](https://user-images.githubusercontent.com/1980296/99895433-43215680-2c56-11eb-8f0e-e1018c3d8eb4.png)


(I feel kind of ashamed of the Before one now :) ) 